### PR TITLE
R9/STM32: Support for half duplex uart operation

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -2,20 +2,17 @@
 #include "../../src/targets.h"
 #include "CRSF.h"
 #include "../../lib/FIFO/FIFO.h"
-#include "HardwareSerial.h"
 
 #ifdef PLATFORM_ESP32
-HardwareSerial SerialPort(1);
-HardwareSerial CRSF::Port = SerialPort;
+HwSerial SerialPort(1);
+HwSerial CRSF::Port = SerialPort;
 portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;
 TaskHandle_t xHandleSerialOutFIFO = NULL;
 TaskHandle_t xESP32uartTask = NULL;
 #endif
 
 #ifdef TARGET_R9M_TX
-HardwareSerial CRSF::Port(USART3);
-#include "stm32f1xx_hal.h"
-#include "stm32f1xx_hal_gpio.h"
+HwSerial CRSF::Port(USART3);
 #endif
 
 ///Out FIFO to buffer messages///
@@ -614,11 +611,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
                                 Serial.println();
                                 CRSFframeActive = false;
                                 SerialInPacketPtr = 0;
-                                Port.flush();
-                                while (CRSF::Port.available())
-                                {
-                                    CRSF::Port.read(); // dunno why but the flush() method wasn't working
-                                }
+                                FlushSerial();
                                 BadPktsCount++;
                             }
                         }
@@ -633,19 +626,18 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
                         if (SerialOutFIFO.size() >= (peekVal + 1))
                         {
                             digitalWrite(BUFFER_OE, HIGH);
+                            CRSF::Port.enable_transmitter();
 
                             uint8_t OutPktLen = SerialOutFIFO.pop();
                             uint8_t OutData[OutPktLen];
 
                             SerialOutFIFO.popBytes(OutData, OutPktLen);
                             CRSF::Port.write(OutData, OutPktLen); // write the packet out
-                            CRSF::Port.flush();
+                            CRSF::Port.flush(); // Wait until TX is done
+                            CRSF::Port.enable_receiver();
                             digitalWrite(BUFFER_OE, LOW);
 
-                            while (CRSF::Port.available())
-                            {
-                                CRSF::Port.read(); // dunno why but the flush() method wasn't working
-                            }
+                            //FlushSerial();
                         }
                     }
                 }
@@ -710,5 +702,5 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
 
     void ICACHE_RAM_ATTR CRSF::FlushSerial()
     {
-        CRSF::Port.flush();
+        CRSF::Port.flush_read();
     }

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -2,7 +2,7 @@
 #define H_CRSF
 
 #include <Arduino.h>
-#include "HardwareSerial.h"
+#include "HwSerial.h"
 
 #ifdef PLATFORM_ESP32
 #include "esp32-hal-uart.h"
@@ -348,9 +348,10 @@ public:
     {
         _dev->println("CRSF Lib Ready!");
     }
+
 #endif
 
-    static HardwareSerial Port;
+    static HwSerial Port;
     //static Stream *Port;
 
     static volatile uint16_t ChannelDataIn[16];

--- a/src/lib/HwSerial/HwSerial.cpp
+++ b/src/lib/HwSerial/HwSerial.cpp
@@ -1,0 +1,1 @@
+#include "HwSerial.h"

--- a/src/lib/HwSerial/HwSerial.h
+++ b/src/lib/HwSerial/HwSerial.h
@@ -1,0 +1,49 @@
+#ifndef SERIAL_H_
+#define SERIAL_H_
+
+#include <HardwareSerial.h>
+
+class HwSerial : public HardwareSerial
+{
+public:
+#if defined(PLATFORM_ESP32) || defined(PLATFORM_ESP8266)
+    HwSerial(int uart_nr) : HardwareSerial(uart_nr){};
+#else
+    HwSerial(uint32_t _rx, uint32_t _tx) : HardwareSerial(_rx, _tx){};
+    HwSerial(PinName _rx, PinName _tx) : HardwareSerial(_rx, _tx){};
+    HwSerial(void *peripheral) : HardwareSerial(peripheral){};
+#endif
+
+#ifdef __STM32F1xx_HAL_UART_H
+    void begin(unsigned long baud)
+    {
+        HwSerial::begin(baud, SERIAL_8N1);
+    }
+    void begin(unsigned long baud, uint8_t mode)
+    {
+        HardwareSerial::begin(baud, mode);
+        enable_receiver();
+    }
+#endif
+
+    void flush_read(void)
+    {
+        while (available())
+            read();
+    }
+
+    void enable_receiver(void)
+    {
+#ifdef __STM32F1xx_HAL_UART_H
+        HAL_HalfDuplex_EnableReceiver(&_serial.handle);
+#endif
+    }
+    void enable_transmitter(void)
+    {
+#ifdef __STM32F1xx_HAL_UART_H
+        HAL_HalfDuplex_EnableTransmitter(&_serial.handle);
+#endif
+    }
+};
+
+#endif /* SERIAL_H_ */


### PR DESCRIPTION
Arduino core HardwareSerial wrapped by HwSerial to be able
to access protected members. Then enable_receiver and
enable_transmitter can called to disable unwanted data
reception while transmitting.