### PR TITLE
Settings: air rate settings array copy removed

### DIFF
--- a/src/lib/BUTTON/button.h
+++ b/src/lib/BUTTON/button.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../src/targets.h"
 #include <Arduino.h>
+#include "../../src/targets.h"
 
 class button
 {

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -1,7 +1,7 @@
+#include <Arduino.h>
 #include "../../src/targets.h"
 #include "CRSF.h"
 #include "../../lib/FIFO/FIFO.h"
-#include <Arduino.h>
 #include "HardwareSerial.h"
 
 #ifdef PLATFORM_ESP32
@@ -508,7 +508,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
             {
                 if (BadPktsCount >= GoodPktsCount)
                 {
-                    Serial.println("Too many bad UART RX packets! Bad:Good = ");-
+                    Serial.println("Too many bad UART RX packets! Bad:Good = ");
                     Serial.print(BadPktsCount);
                     Serial.print(":");
                     Serial.println(GoodPktsCount);
@@ -672,6 +672,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
 
             memcpy((uint16_t *)ChannelDataInPrev, (uint16_t *)ChannelDataIn, 16); //before we write the new RC channel data copy the old data
 
+#if 0
             const crsf_channels_t *const rcChannels = (crsf_channels_t *)&CRSF::SerialInBuffer[SERIAL_PACKET_OFFSET];
             ChannelDataIn[0] = (rcChannels->ch0);
             ChannelDataIn[1] = (rcChannels->ch1);
@@ -689,6 +690,11 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
             ChannelDataIn[13] = (rcChannels->ch13);
             ChannelDataIn[14] = (rcChannels->ch14);
             ChannelDataIn[15] = (rcChannels->ch15);
+#else
+    memcpy((void *)ChannelDataIn,
+           (void *)&CRSF::SerialInBuffer[SERIAL_PACKET_OFFSET],
+           sizeof(crsf_channels_t));
+#endif
         }
 
         void ICACHE_RAM_ATTR CRSF::FlushSerial()

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -285,13 +285,10 @@ static inline uint16_t ICACHE_RAM_ATTR BIT_to_CRSF(uint8_t Val)
 };
 
 static inline uint16_t ICACHE_RAM_ATTR CRSF_to_UINT10(uint16_t Val) { return round(fmap(Val, 172.0, 1811.0, 0.0, 1023.0)); };
-static inline uint16_t ICACHE_RAM_ATTR UINT_to_CRSF(uint16_t Val);
+//static inline uint16_t ICACHE_RAM_ATTR UINT_to_CRSF(uint16_t Val);
 
-static uint8_t ICACHE_RAM_ATTR CalcCRC(volatile uint8_t *data, int length);
-static uint8_t ICACHE_RAM_ATTR CalcCRC(uint8_t *data, int length);
-static uint8_t ICACHE_RAM_ATTR CalcCRCcmd(uint8_t *data, int length);
 
-uint8_t ICACHE_RAM_ATTR CalcCRC(volatile uint8_t *data, int length)
+static inline uint8_t ICACHE_RAM_ATTR CalcCRC(volatile uint8_t *data, int length)
 {
     uint8_t crc = 0;
     for (uint8_t i = 0; i < length; i++)
@@ -301,7 +298,7 @@ uint8_t ICACHE_RAM_ATTR CalcCRC(volatile uint8_t *data, int length)
     return crc;
 }
 
-uint8_t ICACHE_RAM_ATTR CalcCRC(uint8_t *data, int length)
+static inline uint8_t ICACHE_RAM_ATTR CalcCRC(uint8_t *data, int length)
 {
     uint8_t crc = 0;
     for (uint8_t i = 0; i < length; i++)
@@ -311,7 +308,7 @@ uint8_t ICACHE_RAM_ATTR CalcCRC(uint8_t *data, int length)
     return crc;
 }
 
-uint8_t ICACHE_RAM_ATTR CalcCRCcmd(uint8_t *data, int length)
+static inline uint8_t ICACHE_RAM_ATTR CalcCRCcmd(uint8_t *data, int length)
 {
     uint8_t crc = 0;
     for (uint8_t i = 0; i < length; i++)

--- a/src/lib/DAC/DAC.cpp
+++ b/src/lib/DAC/DAC.cpp
@@ -1,4 +1,3 @@
-#pragma once
 
 #ifdef TARGET_R9M_TX
 

--- a/src/lib/FIFO/FIFO.cpp
+++ b/src/lib/FIFO/FIFO.cpp
@@ -1,21 +1,21 @@
 /*
  * FIFO Buffer
  * Implementation uses arrays to conserve memory
- * 
+ *
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Daniel Eisterhold
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,8 +23,8 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
- * 
+ *
+ *
  * Modified/Ammended by Alessandro Carcione 2020
  */
 #include "FIFO.h"
@@ -81,7 +81,7 @@ uint8_t ICACHE_RAM_ATTR FIFO::pop()
     if (numElements == 0)
     {
         //    Serial.println(F("Buffer empty"));
-        return NULL;
+        return 0;
     }
     else
     {
@@ -116,7 +116,7 @@ uint8_t ICACHE_RAM_ATTR FIFO::peek()
     if (numElements == 0)
     {
         //    Serial.println(F("Buffer empty"));
-        return NULL;
+        return 0;
     }
     else
     {

--- a/src/lib/FIFO/FIFO.h
+++ b/src/lib/FIFO/FIFO.h
@@ -1,21 +1,21 @@
 /*
  * FIFO Buffer
  * Implementation uses arrays to conserve memory
- * 
+ *
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Daniel Eisterhold
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,15 +23,15 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
- * 
- * 
+ *
+ *
+ *
  * Modified/Ammended by Alessandro Carcione 2020
  */
 
 #pragma once
 
-#include "Arduino.h"
+#include <Arduino.h>
 #include "../../src/targets.h"
 
 #define FIFO_SIZE 512
@@ -48,7 +48,7 @@ public:
     FIFO();
     ~FIFO();
     void ICACHE_RAM_ATTR push(uint8_t data);
-    void ICACHE_RAM_ATTR pushBytes(uint8_t* data, int len);
+    void ICACHE_RAM_ATTR pushBytes(uint8_t *data, int len);
     uint8_t ICACHE_RAM_ATTR pop();
     void ICACHE_RAM_ATTR popBytes(uint8_t *data, int len);
     uint8_t ICACHE_RAM_ATTR peek();

--- a/src/lib/LoRaRadioLib/LoRa_SX1278.cpp
+++ b/src/lib/LoRaRadioLib/LoRa_SX1278.cpp
@@ -15,6 +15,7 @@ uint8_t SX1278rxCont()
   // execute common part
   //return
   SX127xDriver::RXnb();
+  (void)headerExplMode;
   return (ERR_NONE);
 }
 
@@ -28,6 +29,7 @@ uint8_t SX1278rxSingle(uint8_t *data, uint8_t length)
   }
 
   // execute common part
+  (void)headerExplMode;
   return SX127xDriver::RXsingle(data, length);
 }
 

--- a/src/lib/LoRaRadioLib/LoRa_SX127x.cpp
+++ b/src/lib/LoRaRadioLib/LoRa_SX127x.cpp
@@ -163,7 +163,7 @@ uint8_t SX127xDriver::SetOutputPower(uint8_t Power)
 {
   //todo make function turn on PA_BOOST ect
   uint8_t status = setRegValue(SX127X_REG_PA_CONFIG, SX127X_PA_SELECT_BOOST | SX127X_MAX_OUTPUT_POWER | Power, 7, 0);
-  
+
   currPWR = Power;
 
   if (status != ERR_NONE)
@@ -423,7 +423,6 @@ uint8_t SX127xDriver::TX(uint8_t *data, uint8_t length)
 
 //on the ESP32 we can use a hardware timer to do fancy things like schedule regular TX transmissions
 
-static SemaphoreHandle_t timer_sem;
 hw_timer_t *timer = NULL;
 portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
 TaskHandle_t TimerTask_handle = NULL;
@@ -731,6 +730,7 @@ uint8_t SX127xDriver::Config(Bandwidth bw, SpreadingFactor sf, CodingRate cr, ui
   {
     SX1278config(bw, sf, cr, freq, syncWord);
   }
+  return 0;
 }
 
 uint8_t SX127xDriver::SX127xConfig(uint8_t bw, uint8_t sf, uint8_t cr, uint32_t freq, uint8_t syncWord)

--- a/src/src/ESP8266_hwTimer.h
+++ b/src/src/ESP8266_hwTimer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "../../src/targets.h"
 #include <Arduino.h>
 #include <stdio.h>
+#include "../../src/targets.h"
 
 #define TimerIntervalUSDefault 20000
 
@@ -14,7 +14,6 @@ extern "C"
 class hwTimer
 {
 public:
-
 	static volatile uint32_t HWtimerInterval;
 	static volatile bool TickTock;
 	static volatile int16_t PhaseShift;

--- a/src/src/LED.h
+++ b/src/src/LED.h
@@ -1,24 +1,24 @@
 /// LED SUPPORT ///////
 #ifdef PLATFORM_ESP32
-  #include <NeoPixelBus.h>
-  const uint16_t PixelCount = 4; // this example assumes 4 pixels, making it smaller will cause a failure
-  const uint8_t PixelPin = 27;   // make sure to set this to the correct pin, ignored for Esp8266
-  const uint8_t numberOfLEDs = 3;
-  uint16_t LEDGlowIndex = 0;
-  #define colorSaturation 50
-  NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+#include <NeoPixelBus.h>
+const uint16_t PixelCount = 4; // this example assumes 4 pixels, making it smaller will cause a failure
+const uint8_t PixelPin = 27;   // make sure to set this to the correct pin, ignored for Esp8266
+const uint8_t numberOfLEDs = 3;
+uint16_t LEDGlowIndex = 0;
+#define colorSaturation 50
+NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
 
-  RgbColor red(colorSaturation, 0, 0);
-  RgbColor green(0, colorSaturation, 0);
-  RgbColor blue(0, 0, colorSaturation);
-  RgbColor white(colorSaturation);
-  RgbColor black(0);
+RgbColor red(colorSaturation, 0, 0);
+RgbColor green(0, colorSaturation, 0);
+RgbColor blue(0, 0, colorSaturation);
+RgbColor white(colorSaturation);
+RgbColor black(0);
 
-  HslColor hslRed(red);
-  HslColor hslGreen(green);
-  HslColor hslBlue(blue);
-  HslColor hslWhite(white);
-  HslColor hslBlack(black);
+HslColor hslRed(red);
+HslColor hslGreen(green);
+HslColor hslBlue(blue);
+HslColor hslWhite(white);
+HslColor hslBlack(black);
 #endif
 
 void updateLEDs(uint8_t isRXconnected, uint8_t tlm)
@@ -26,29 +26,34 @@ void updateLEDs(uint8_t isRXconnected, uint8_t tlm)
 #ifdef PLATFORM_ESP32
   LEDGlowIndex = millis() % 5000;
 
-  if(LEDGlowIndex < 2500)
+  if (LEDGlowIndex < 2500)
   {
     LEDGlowIndex = LEDGlowIndex / 10;
-  } else
+  }
+  else
   {
     LEDGlowIndex = 250 - (LEDGlowIndex - 2500) / 10;
   }
 
-  for(int n = 0; n < numberOfLEDs; n++) strip.SetPixelColor(n, RgbColor(LEDGlowIndex, LEDGlowIndex, LEDGlowIndex));
+  for (int n = 0; n < numberOfLEDs; n++)
+    strip.SetPixelColor(n, RgbColor(LEDGlowIndex, LEDGlowIndex, LEDGlowIndex));
 
-  if(isRXconnected || tlm == 0)
+  if (isRXconnected || tlm == 0)
   {
-    if(ExpressLRS_currAirRate.enum_rate == RATE_200HZ)
+    if (ExpressLRS_currAirRate->enum_rate == RATE_200HZ)
     {
-      for(int n = 0; n < numberOfLEDs; n++) strip.SetPixelColor(n, RgbColor(0, 0, LEDGlowIndex));
+      for (int n = 0; n < numberOfLEDs; n++)
+        strip.SetPixelColor(n, RgbColor(0, 0, LEDGlowIndex));
     }
-    if(ExpressLRS_currAirRate.enum_rate == RATE_100HZ)
+    if (ExpressLRS_currAirRate->enum_rate == RATE_100HZ)
     {
-      for(int n = 0; n < numberOfLEDs; n++) strip.SetPixelColor(n, RgbColor(0, LEDGlowIndex, 0));
+      for (int n = 0; n < numberOfLEDs; n++)
+        strip.SetPixelColor(n, RgbColor(0, LEDGlowIndex, 0));
     }
-    if(ExpressLRS_currAirRate.enum_rate == RATE_50HZ)
+    if (ExpressLRS_currAirRate->enum_rate == RATE_50HZ)
     {
-      for(int n = 0; n < numberOfLEDs; n++) strip.SetPixelColor(n, RgbColor(LEDGlowIndex, 0, 0));
+      for (int n = 0; n < numberOfLEDs; n++)
+        strip.SetPixelColor(n, RgbColor(LEDGlowIndex, 0, 0));
     }
   }
   strip.Show();

--- a/src/src/STM32_hwTimer.h
+++ b/src/src/STM32_hwTimer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "../../src/targets.h"
 #include <Arduino.h>
 #include <stdio.h>
+#include "../../src/targets.h"
 
 #define TimerIntervalUSDefault 20000
 

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -7,17 +7,26 @@ void commonConfig()
 extern SX127xDriver Radio;
 
 // TODO: Validate values for RFmodeCycleAddtionalTime and RFmodeCycleInterval for rates lower than 50HZ
-expresslrs_mod_settings_s RF_RATE_200HZ =  {BW_500_00_KHZ, SF_6,  CR_4_5, -112, 5000,   200, TLM_RATIO_1_64,   4, 8,  RATE_200HZ, 1000, 1500};
-expresslrs_mod_settings_s RF_RATE_100HZ =  {BW_500_00_KHZ, SF_7,  CR_4_7, -117, 10000,  100, TLM_RATIO_1_32,   4, 8, RATE_100HZ, 2000, 2000};
-expresslrs_mod_settings_s RF_RATE_50HZ =   {BW_500_00_KHZ, SF_8,  CR_4_7, -120, 20000,  50,  TLM_RATIO_1_16,   2, 10, RATE_50HZ, 6000, 2500};
-expresslrs_mod_settings_s RF_RATE_25HZ =   {BW_250_00_KHZ, SF_8,  CR_4_7, -123, 40000,  25,  TLM_RATIO_NO_TLM, 2, 8,  RATE_25HZ, 6000, 2500};
-expresslrs_mod_settings_s RF_RATE_4HZ =    {BW_250_00_KHZ, SF_11, CR_4_5, -131, 250000, 4,   TLM_RATIO_NO_TLM, 2, 8,  RATE_4HZ, 6000, 2500};
+const expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
+    {BW_500_00_KHZ, SF_6, CR_4_5, -112, 5000, 200, TLM_RATIO_1_64, 4, 8, RATE_200HZ, 1000, 1500},
+    {BW_500_00_KHZ, SF_7, CR_4_7, -117, 10000, 100, TLM_RATIO_1_32, 4, 8, RATE_100HZ, 2000, 2000},
+    {BW_500_00_KHZ, SF_8, CR_4_7, -120, 20000, 50, TLM_RATIO_1_16, 2, 10, RATE_50HZ, 6000, 2500},
+    {BW_250_00_KHZ, SF_8, CR_4_7, -123, 40000, 25, TLM_RATIO_NO_TLM, 2, 8, RATE_25HZ, 6000, 2500},
+    {BW_250_00_KHZ, SF_11, CR_4_5, -131, 250000, 4, TLM_RATIO_NO_TLM, 2, 8, RATE_4HZ, 6000, 2500},
+};
 
-const expresslrs_mod_settings_s ExpressLRS_AirRateConfig[5] = {RF_RATE_200HZ, RF_RATE_100HZ, RF_RATE_50HZ, RF_RATE_25HZ, RF_RATE_4HZ};
+const expresslrs_mod_settings_s * get_elrs_airRateConfig(expresslrs_RFrates_e rate)
+{
+    if (RATE_MAX <= rate)
+        rate = RATE_4HZ;
+    else if (RATE_200HZ >= rate)
+        rate = RATE_200HZ;
+    return &ExpressLRS_AirRateConfig[rate];
+}
 
-expresslrs_mod_settings_s ExpressLRS_nextAirRate;
-expresslrs_mod_settings_s ExpressLRS_currAirRate;
-expresslrs_mod_settings_s ExpressLRS_prevAirRate;
+//const expresslrs_mod_settings_s * ExpressLRS_nextAirRate;
+const expresslrs_mod_settings_s * ExpressLRS_currAirRate;
+const expresslrs_mod_settings_s * ExpressLRS_prevAirRate;
 
 int8_t ExpressLRS_currPower = 0;
 int8_t ExpressLRS_prevPower = 0;
@@ -40,7 +49,7 @@ int16_t MeasureNoiseFloor()
     int NUM_READS = RSSI_FLOOR_NUM_READS * NR_FHSS_ENTRIES;
     float returnval = 0;
 
-    for (int freq = 0; freq < NR_FHSS_ENTRIES; freq++)
+    for (uint32_t freq = 0; freq < NR_FHSS_ENTRIES; freq++)
     {
         FHSSsetCurrIndex(freq);
         Radio.SetMode(SX127X_CAD);

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -8,11 +8,9 @@
 // #define Regulatory_Domain_EU_433
 // #define Regulatory_Domain_FCC_915
 
-
 #include "FHSS.h"
 #include "LoRaRadioLib.h"
 #include <Arduino.h>
-
 
 // Wifi starts if no connection is found between 10 and 11 seconds after boot
 #define Auto_WiFi_On_Boot
@@ -55,11 +53,12 @@ typedef enum
 
 typedef enum
 {
-    RATE_4HZ = 4,
-    RATE_25HZ = 3,
-    RATE_50HZ = 2,
-    RATE_100HZ = 1,
     RATE_200HZ = 0,
+    RATE_100HZ,
+    RATE_50HZ,
+    RATE_25HZ,
+    RATE_4HZ,
+    RATE_MAX
 } expresslrs_RFrates_e; // Max value of 16 since only 4 bits have been assigned in the sync package.
 
 #define MaxRFrate 2
@@ -80,17 +79,11 @@ typedef struct expresslrs_mod_settings_s
     uint16_t RFmodeCycleInterval;
 } expresslrs_mod_settings_t;
 
-extern expresslrs_mod_settings_s RF_RATE_200HZ;
-extern expresslrs_mod_settings_s RF_RATE_100HZ;
-extern expresslrs_mod_settings_s RF_RATE_50HZ;
-extern expresslrs_mod_settings_s RF_RATE_25HZ;
-extern expresslrs_mod_settings_s RF_RATE_4HZ;
+const expresslrs_mod_settings_s *get_elrs_airRateConfig(expresslrs_RFrates_e rate);
 
-extern const expresslrs_mod_settings_s ExpressLRS_AirRateConfig[5];
-
-extern expresslrs_mod_settings_s ExpressLRS_nextAirRate;
-extern expresslrs_mod_settings_s ExpressLRS_currAirRate;
-extern expresslrs_mod_settings_s ExpressLRS_prevAirRate;
+//extern const expresslrs_mod_settings_s * ExpressLRS_nextAirRate;
+extern const expresslrs_mod_settings_s *ExpressLRS_currAirRate;
+extern const expresslrs_mod_settings_s *ExpressLRS_prevAirRate;
 
 #define MaxPower100mW_Module 20
 #define MaxPower1000mW_Module 30

--- a/src/src/rx_LinkQuality.h
+++ b/src/src/rx_LinkQuality.h
@@ -33,4 +33,5 @@ int ICACHE_RAM_ATTR LQreset()
     {
         linkQualityArray[i] = 0;
     }
+    return 0;
 }

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -21,11 +21,11 @@
 #endif
 
 //// CONSTANTS ////
-#define BUTTON_SAMPLE_INTERVAL          150
-#define WEB_UPDATE_PRESS_INTERVAL       2000 // hold button for 2 sec to enable webupdate mode
-#define BUTTON_RESET_INTERVAL           4000 //hold button for 4 sec to reboot RX
-#define WEB_UPDATE_LED_FLASH_INTERVAL   25
-#define SEND_LINK_STATS_TO_FC_INTERVAL  100
+#define BUTTON_SAMPLE_INTERVAL 150
+#define WEB_UPDATE_PRESS_INTERVAL 2000 // hold button for 2 sec to enable webupdate mode
+#define BUTTON_RESET_INTERVAL 4000     //hold button for 4 sec to reboot RX
+#define WEB_UPDATE_LED_FLASH_INTERVAL 25
+#define SEND_LINK_STATS_TO_FC_INTERVAL 100
 ///////////////////
 
 hwTimer hwTimer;
@@ -90,14 +90,14 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
     crsf.LinkStatistics.uplink_RSSI_2 = 0;
     crsf.LinkStatistics.uplink_SNR = Radio.GetLastPacketSNR() * 10;
     crsf.LinkStatistics.uplink_Link_quality = linkQuality;
-    crsf.LinkStatistics.rf_Mode = 4 - ExpressLRS_currAirRate.enum_rate;
+    crsf.LinkStatistics.rf_Mode = 4 - ExpressLRS_currAirRate->enum_rate;
 
     //Serial.println(crsf.LinkStatistics.uplink_RSSI_1);
 }
 
 void ICACHE_RAM_ATTR HandleFHSS()
 {
-    uint8_t modresult = (NonceRXlocal + 1) % ExpressLRS_currAirRate.FHSShopInterval;
+    uint8_t modresult = (NonceRXlocal + 1) % ExpressLRS_currAirRate->FHSShopInterval;
     if (modresult != 0)
     {
         return;
@@ -118,7 +118,7 @@ void ICACHE_RAM_ATTR HandleSendTelemetryResponse()
     {
         return; // don't bother sending tlm if disconnected
     }
-    uint8_t modresult = (NonceRXlocal + 1) % TLMratioEnumToValue(ExpressLRS_currAirRate.TLMinterval);
+    uint8_t modresult = (NonceRXlocal + 1) % TLMratioEnumToValue(ExpressLRS_currAirRate->TLMinterval);
     if (modresult != 0)
     {
         return;
@@ -173,7 +173,7 @@ void ICACHE_RAM_ATTR LostConnection()
 
 #ifdef PLATFORM_STM32
 
-        digitalWrite(GPIO_PIN_LED_GREEN, LOW);
+    digitalWrite(GPIO_PIN_LED_GREEN, LOW);
 #endif
 }
 
@@ -200,8 +200,7 @@ void ICACHE_RAM_ATTR GotConnection()
 
 #ifdef PLATFORM_STM32
 
-        digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
-
+    digitalWrite(GPIO_PIN_LED_GREEN, HIGH);
 
 #endif
 }
@@ -268,7 +267,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
         crsf.sendRCFrameToFC();
         break;
 
-    case SWITCH_DATA_PACKET:                                                                                                    // Switch Data Packet
+    case SWITCH_DATA_PACKET:                                                                                      // Switch Data Packet
         if ((Radio.RXdataBuffer[3] == Radio.RXdataBuffer[1]) && (Radio.RXdataBuffer[4] == Radio.RXdataBuffer[2])) // extra layer of protection incase the crc and addr headers fail us.
         {
             UnpackSwitchData();
@@ -296,7 +295,7 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
                 GotConnection();
             }
 
-            // if (ExpressLRS_currAirRate.enum_rate == !(expresslrs_RFrates_e)(Radio.RXdataBuffer[2] & 0b00001111))
+            // if (ExpressLRS_currAirRate->enum_rate == !(expresslrs_RFrates_e)(Radio.RXdataBuffer[2] & 0b00001111))
             // {
             //     Serial.println("update air rate");
             //     SetRFLinkRate(ExpressLRS_AirRateConfig[Radio.RXdataBuffer[3]]);
@@ -314,11 +313,11 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
 
     addPacketToLQ();
 
-    HWtimerError = ((micros() - hwTimer.LastCallbackMicrosTick) % ExpressLRS_currAirRate.interval);
-    Offset = LPF_Offset.update(HWtimerError - (ExpressLRS_currAirRate.interval >> 1)); //crude 'locking function' to lock hardware timer to transmitter, seems to work well enough
+    HWtimerError = ((micros() - hwTimer.LastCallbackMicrosTick) % ExpressLRS_currAirRate->interval);
+    Offset = LPF_Offset.update(HWtimerError - (ExpressLRS_currAirRate->interval >> 1)); //crude 'locking function' to lock hardware timer to transmitter, seems to work well enough
     hwTimer.phaseShift(uint32_t((Offset >> 4) + timerOffset));
 
-    if (((NonceRXlocal + 1) % ExpressLRS_currAirRate.FHSShopInterval) == 0) //premept the FHSS if we already know we'll have to do it next timer tick.
+    if (((NonceRXlocal + 1) % ExpressLRS_currAirRate->FHSShopInterval) == 0) //premept the FHSS if we already know we'll have to do it next timer tick.
     {
         int32_t freqerror = LPF_FreqError.update(Radio.GetFrequencyError());
         //Serial.print(freqerror);
@@ -406,13 +405,14 @@ void ICACHE_RAM_ATTR sampleButton()
     buttonPrevValue = buttonValue;
 }
 
-void ICACHE_RAM_ATTR SetRFLinkRate(expresslrs_mod_settings_s mode) // Set speed of RF link (hz)
+void ICACHE_RAM_ATTR SetRFLinkRate(expresslrs_RFrates_e rate) // Set speed of RF link (hz)
 {
+    const expresslrs_mod_settings_s *const mode = get_elrs_airRateConfig(rate);
     Radio.StopContRX();
-    Radio.Config(mode.bw, mode.sf, mode.cr, Radio.currFreq, Radio._syncWord);
+    Radio.Config(mode->bw, mode->sf, mode->cr, Radio.currFreq, Radio._syncWord);
     ExpressLRS_currAirRate = mode;
-    hwTimer.updateInterval(mode.interval);
-    LPF_PacketInterval.init(mode.interval);
+    hwTimer.updateInterval(mode->interval);
+    LPF_PacketInterval.init(mode->interval);
     //LPF_Offset.init(0);
     //InitHarwareTimer();
     Radio.RXnb();
@@ -454,7 +454,7 @@ void setup()
     Serial.println("Setting 433MHz Mode");
     Radio.RFmodule = RFMOD_SX1278; //define radio module here
 #else
-    #error No regulatory domain defined, please define one in common.h
+#error No regulatory domain defined, please define one in common.h
 #endif
 
     FHSSrandomiseFHSSsequence();
@@ -479,29 +479,29 @@ void setup()
     hwTimer.callbackTock = &HWtimerCallback;
     hwTimer.init();
 
-    SetRFLinkRate(RF_RATE_200HZ);
+    SetRFLinkRate(RATE_200HZ);
     hwTimer.init();
 }
 
 void loop()
 {
 
-    if (millis() > (RFmodeLastCycled + ExpressLRS_currAirRate.RFmodeCycleInterval + ((connectionState == tentative) ? ExpressLRS_currAirRate.RFmodeCycleAddtionalTime : 0))) // connection = tentative we add alittle delay
+    if (millis() > (RFmodeLastCycled + ExpressLRS_currAirRate->RFmodeCycleInterval + ((connectionState == tentative) ? ExpressLRS_currAirRate->RFmodeCycleAddtionalTime : 0))) // connection = tentative we add alittle delay
     {
         if ((connectionState == disconnected) && !webUpdateMode)
         {
             Radio.SetFrequency(GetInitialFreq());
-            SetRFLinkRate(ExpressLRS_AirRateConfig[scanIndex % 3]); //switch between 200hz, 100hz, 50hz, rates
+            SetRFLinkRate((expresslrs_RFrates_e)(scanIndex % RATE_25HZ)); //switch between 200hz, 100hz, 50hz, rates
             LQreset();
             digitalWrite(GPIO_PIN_LED, LED);
             LED = !LED;
-            Serial.println(ExpressLRS_currAirRate.interval);
+            Serial.println(ExpressLRS_currAirRate->interval);
             scanIndex++;
         }
         RFmodeLastCycled = millis();
     }
 
-    if (millis() > (LastValidPacket + ExpressLRS_currAirRate.RFmodeCycleAddtionalTime)) // check if we lost conn.
+    if (millis() > (LastValidPacket + ExpressLRS_currAirRate->RFmodeCycleAddtionalTime)) // check if we lost conn.
     {
         LostConnection();
     }


### PR DESCRIPTION
No need to copy big struct and replaced by pointers to minimize
unnecessary copying and data can be kept constant.

Some code and compiler warning cleanups.