### PR TITLE
build: read user specified defines from file

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -5,3 +5,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 __pycache__
+*.pyc
+user_defines.txt

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -26,6 +26,7 @@ build_flags =
 	-D TARGET_1000mW_MODULE
 	-D PLATFORM_ESP32
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*> -<rx_main.cpp> -<rx_*.cpp>
+extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = NeoPixelBus
 
 [env:ExpLRS_TX_V3_100mW]
@@ -42,6 +43,7 @@ build_flags =
 	-D TARGET_100mW_MODULE
 	-D PLATFORM_ESP32
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*> -<rx_main.cpp> -<rx_*.cpp>
+extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = NeoPixelBus
 
 [env:ExpLRS_TX_V3_100mW_LEGACY]
@@ -59,6 +61,7 @@ build_flags =
 	-D TARGET_100mW_MODULE
 	-D PLATFORM_ESP32
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*> -<rx_main.cpp> -<rx_*.cpp>
+extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = NeoPixelBus
 
 [env:TTGO_LORA_V1_TX]
@@ -75,6 +78,7 @@ build_flags =
 	-D TARGET_100mW_MODULE
 	-D PLATFORM_ESP32
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*> -<rx_main.cpp> -<rx_*.cpp>
+extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = NeoPixelBus
 
 [env:TTGO_LORA_V2_TX]
@@ -91,6 +95,7 @@ build_flags =
 	-D TARGET_100mW_MODULE
 	-D PLATFORM_ESP32
 src_filter = ${common_env_data.src_filter} -<ESP8266*.*> -<STM32*.*> -<rx_*.cpp>
+extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = NeoPixelBus
 
 [env:ExpLRS_RX_V3]
@@ -110,6 +115,7 @@ build_flags =
 	-O3
 board_build.f_cpu = 80000000L
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<STM32*.*> -<tx_*.cpp> -<WS281B*.*>
+extra_scripts = ${common_env_data.extra_scripts}
 
 [env:ExpLRS_RX_V3_BetaflightPassthrough]
 platform = ${env:ExpLRS_RX_V3.platform}
@@ -119,6 +125,7 @@ monitor_dtr = 0
 monitor_rts = 0
 build_flags = ${env:ExpLRS_RX_V3.build_flags}
 src_filter = ${env:ExpLRS_RX_V3.src_filter}
+extra_scripts = ${common_env_data.extra_scripts}
 upload_speed = 115200
 upload_protocol = custom
 upload_command =
@@ -137,6 +144,7 @@ monitor_rts = 0
 build_flags = ${env:ExpLRS_RX_V3.build_flags}
 board_build.f_cpu = 80000000L
 src_filter = ${env:ExpLRS_RX_V3.src_filter}
+extra_scripts = ${common_env_data.extra_scripts}
 
 [env:R9MM_R9MINI_RX_STM32F301_STLINK]
 platform = ststm32
@@ -153,7 +161,9 @@ build_flags =
 	-Wl,-Tvariants/R9MM/R9MM_ldscript.ld
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<tx_*.cpp>
 upload_protocol = custom
-extra_scripts = python/upload_stlink.py
+extra_scripts =
+	${common_env_data.extra_scripts}
+	python/upload_stlink.py
 upload_flags =
     BOOTLOADER=bootloader/bootloader.hex
     VECT_OFFSET=0x8000
@@ -165,6 +175,7 @@ board = ${env:R9MM_R9MINI_RX_STM32F301_STLINK.board}
 build_unflags = ${env:R9MM_R9MINI_RX_STM32F301_STLINK.build_unflags}
 build_flags = ${env:R9MM_R9MINI_RX_STM32F301_STLINK.build_flags}
 src_filter = ${env:R9MM_R9MINI_RX_STM32F301_STLINK.src_filter}
+extra_scripts = ${common_env_data.extra_scripts}
 upload_protocol = custom
 upload_command =
 	python python/runpython.py $PYTHONEXE python/BFinitPassthrough.py 420000
@@ -180,6 +191,7 @@ build_flags =
 	-D PLATFORM_STM32
 	-D HSE_VALUE=12000000U
 	-O2
+extra_scripts = ${common_env_data.extra_scripts}
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<rx_*.cpp>
 upload_protocol = stlink
 
@@ -192,9 +204,10 @@ build_flags =
 	${env:R9M_TX_2018_STM32F301.build_flags}
 	-DVECT_TAB_OFFSET=0x2000U
 	-Wl,-Tvariants/R9M_ldscript.ld
-#	-DJUST_BEEP_ONCE=1
 src_filter = ${env:R9M_TX_2018_STM32F301.src_filter}
-extra_scripts = python/opentx.py
+extra_scripts =
+	${common_env_data.extra_scripts}
+	python/opentx.py
 upload_protocol = custom
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
@@ -203,3 +216,4 @@ board_build.flash_offset = 0x2000
 
 [common_env_data]
 src_filter = +<*> -<.git/> -<svn/> -<example/> -<examples/> -<test/> -<tests/> -<*.py>
+extra_scripts = pre:python/build_flags.py

--- a/src/python/build_flags.py
+++ b/src/python/build_flags.py
@@ -1,0 +1,22 @@
+Import("env")
+import os
+
+def parse_flags(path):
+    build_flags = env['BUILD_FLAGS']
+    try:
+        with open(path, "r") as _f:
+            for line in _f:
+                defines = " ".join(line.split())
+                defines = defines.replace(" = ", "=").split()
+                for define in defines:
+                    define = define.strip()
+                    if define.startswith("-D"):
+                        if "MY_UID" in define and len(define.split(",")) != 6:
+                            raise Exception("UID must be 6 bytes long")
+                        build_flags.append(define)
+    except IOError:
+        print("File '%s' does not exist" % path)
+
+parse_flags("user_defines.txt")
+
+print("build flags: %s" % env['BUILD_FLAGS'])

--- a/src/src/common.cpp
+++ b/src/src/common.cpp
@@ -25,9 +25,13 @@ int8_t ExpressLRS_prevPower = 0;
 connectionState_e connectionState = disconnected;
 connectionState_e connectionStatePrev = disconnected;
 
+#ifndef MY_UID
 //uint8_t UID[6] = {48, 174, 164, 200, 100, 50};
 //uint8_t UID[6] = {180, 230, 45, 152, 126, 65}; //sandro unique ID
 uint8_t UID[6] = {180, 230, 45, 152, 125, 173}; // Wez's unique ID
+#else
+uint8_t UID[6] = {MY_UID};
+#endif
 
 uint8_t CRCCaesarCipher = UID[4];
 uint8_t DeviceAddr = UID[5] & 0b111111; // temporarily based on mac until listen before assigning method merged

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -1,0 +1,22 @@
+#
+# This file can be used to pass defines for compiler
+#
+# Purpose is mainly to define user specific variables
+# without modifying the actual source codes. These
+# flags are passed for all build targets.
+#
+# Define need to start with '-D' keyword
+#
+
+### Enable one of these regulatory domains
+
+#-DRegulatory_Domain_AU_915
+#-DRegulatory_Domain_EU_868
+#-DRegulatory_Domain_AU_433
+#-DRegulatory_Domain_EU_433
+#-DRegulatory_Domain_FCC_915
+
+
+### Set your UID here. Must be 6 bytes!
+
+#-DMY_UID=0xBA,0xBE,0xCA,0xFE,0xAC,0xDC


### PR DESCRIPTION
User can define specific flags in $HOME/expresslrs.txt or
src/user_defines.txt files to avoid unnecessary file modifications.
This also helps to keep specific regulatory domain and UID in
place.

example content of the file:
-DRegulatory_Domain_EU_868
-DMY_UID=0xBA,0xBE,0xCA,0xFE,0xAC,0xDC