### PR TITLE
Sequential and hybrid switch modes

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -59,6 +59,12 @@ volatile uint8_t CRSF::SerialInBuffer[CRSF_MAX_PACKET_LEN] = {0}; // max 64 byte
 volatile uint16_t CRSF::ChannelDataIn[16] = {0};
 volatile uint16_t CRSF::ChannelDataInPrev[16] = {0};
 
+// current and sent switch values, used for prioritising sequential switch transmission
+uint8_t CRSF::currentSwitches[N_SWITCHES] = {0};
+uint8_t CRSF::sentSwitches[N_SWITCHES] = {0};
+
+uint8_t CRSF::nextSwitchIndex=0;    // for round-robin sequential switches
+
 volatile uint8_t CRSF::ParameterUpdateData[2] = {0};
 
 volatile crsf_channels_s CRSF::PackedRCdataOut;
@@ -89,6 +95,56 @@ void CRSF::Begin()
     //The master module requires that the serial communication is bidirectional
     //The Reciever uses seperate rx and tx pins
 }
+
+/**
+ * Determine which switch to send next.
+ * If any switch has changed since last sent, we send the lowest index changed switch
+ * and set nextSwitchIndex to that value + 1.
+ * If no switches have changed then we send nextSwitchIndex and increment the value.
+ * For pure sequential switches, all 8 switches are part of the round-robin sequence.
+ * For hybrid switches, switch 0 is sent with every packet and the rest of the switches
+ * are in the round-robin.
+ */
+uint8_t ICACHE_RAM_ATTR CRSF::getNextSwitchIndex()
+{
+    int i;
+    int firstSwitch = 0; // sequential switches includes switch 0
+
+#if defined HYBRID_SWITCHES_8
+    firstSwitch = 1; // skip 0 since it is sent on every packet
+#endif
+
+    // look for a changed switch
+    for(i=firstSwitch; i<N_SWITCHES; i++) {
+        if (currentSwitches[i] != sentSwitches[i])
+            break;
+    }
+    // if we didn't find a changed switch, we get here with i==N_SWITCHES
+    if (i==N_SWITCHES) i = nextSwitchIndex;
+
+    // keep track of which switch to send next if there are no changed switches
+    // during the next call.
+    nextSwitchIndex = (i+1) % 8;
+
+#ifdef HYBRID_SWITCHES_8
+    // for hydrid switches 0 is sent on every packet, so we can skip
+    // that value for the round-robin
+    if (nextSwitchIndex==0)
+        nextSwitchIndex = 1;
+#endif
+
+    return i;
+}
+
+/**
+ * Record the value of a switch that was sent to the rx
+ */
+void ICACHE_RAM_ATTR CRSF::setSentSwitch(uint8_t index, uint8_t value)
+{
+    sentSwitches[index] = value;
+}
+
+
 
 #if defined(PLATFORM_ESP32) || defined(TARGET_R9M_TX)
 void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
@@ -683,6 +739,21 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
 
 #endif
 
+/**
+ * Convert the rc data corresponding to switches to 2 bit values.
+ *
+ * I'm defining channels 4 through 11 inclusive as representing switches
+ * Take the input values and convert them to the range 0 - 2.
+ * (not 0-3 because most people use 3 way switches and expect the middle
+ *  position to be represented by a middle numeric value)
+ */
+void ICACHE_RAM_ATTR CRSF::updateSwitchValues()
+{
+    for(int i=0; i<N_SWITCHES; i++) {
+        currentSwitches[i] = ChannelDataIn[i+4] / 682; // input is 0 - 2048, output is 0 - 2
+    }
+}
+
     void ICACHE_RAM_ATTR CRSF::GetChannelDataIn() // data is packed as 11 bits per channel
     {
 #define SERIAL_PACKET_OFFSET 3
@@ -706,6 +777,8 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
             ChannelDataIn[13] = (rcChannels->ch13);
             ChannelDataIn[14] = (rcChannels->ch14);
             ChannelDataIn[15] = (rcChannels->ch15);
+
+            updateSwitchValues();
         }
 
     void ICACHE_RAM_ATTR CRSF::FlushSerial()

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -63,7 +63,7 @@ volatile uint16_t CRSF::ChannelDataInPrev[16] = {0};
 uint8_t CRSF::currentSwitches[N_SWITCHES] = {0};
 uint8_t CRSF::sentSwitches[N_SWITCHES] = {0};
 
-uint8_t CRSF::nextSwitchIndex=0;    // for round-robin sequential switches
+uint8_t CRSF::nextSwitchIndex = 0;    // for round-robin sequential switches
 
 volatile uint8_t CRSF::ParameterUpdateData[2] = {0};
 
@@ -107,31 +107,34 @@ void CRSF::Begin()
  */
 uint8_t ICACHE_RAM_ATTR CRSF::getNextSwitchIndex()
 {
-    int i;
     int firstSwitch = 0; // sequential switches includes switch 0
 
-#if defined HYBRID_SWITCHES_8
+    #if defined HYBRID_SWITCHES_8
     firstSwitch = 1; // skip 0 since it is sent on every packet
-#endif
+    #endif
 
     // look for a changed switch
-    for(i=firstSwitch; i<N_SWITCHES; i++) {
+    int i;
+    for(i = firstSwitch; i < N_SWITCHES; i++) {
         if (currentSwitches[i] != sentSwitches[i])
             break;
     }
     // if we didn't find a changed switch, we get here with i==N_SWITCHES
-    if (i==N_SWITCHES) i = nextSwitchIndex;
+    if (i == N_SWITCHES) {
+        i = nextSwitchIndex;
+    }
 
     // keep track of which switch to send next if there are no changed switches
     // during the next call.
-    nextSwitchIndex = (i+1) % 8;
+    nextSwitchIndex = (i + 1) % 8;
 
-#ifdef HYBRID_SWITCHES_8
+    #ifdef HYBRID_SWITCHES_8
     // for hydrid switches 0 is sent on every packet, so we can skip
     // that value for the round-robin
-    if (nextSwitchIndex==0)
+    if (nextSwitchIndex == 0) {
         nextSwitchIndex = 1;
-#endif
+    }
+    #endif
 
     return i;
 }
@@ -143,8 +146,6 @@ void ICACHE_RAM_ATTR CRSF::setSentSwitch(uint8_t index, uint8_t value)
 {
     sentSwitches[index] = value;
 }
-
-
 
 #if defined(PLATFORM_ESP32) || defined(TARGET_R9M_TX)
 void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
@@ -382,10 +383,10 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
 #endif
                         if (BadPktsCount >= GoodPktsCount)
                         {
-                            Serial.print("Too many bad UART RX packets! Bad:Good = ");
-                            Serial.print(BadPktsCount);
-                            Serial.print(":");
-                            Serial.println(GoodPktsCount);
+                            Serial.print("Too many bad UART RX packets!");
+                            // Serial.print(BadPktsCount);
+                            // Serial.print(":");
+                            // Serial.println(GoodPktsCount);
 
                             if (CRSFstate == true)
                             {
@@ -463,7 +464,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
                 void ICACHE_RAM_ATTR CRSF::ESP32uartTask(void *pvParameters) //RTOS task to read and write CRSF packets to the serial port
                 {
                     // CRSF::Port.begin(CRSF_OPENTX_BAUDRATE, SERIAL_8N1, CSFR_RXpin_Module, CSFR_TXpin_Module, false);
-                    //gpio_set_drive_capability((gpio_num_t)CSFR_TXpin_Module, GPIO_DRIVE_CAP_0);
+                    // gpio_set_drive_capability((gpio_num_t)CSFR_TXpin_Module, GPIO_DRIVE_CAP_0);
                     const TickType_t xDelay1 = 1 / portTICK_PERIOD_MS;
                     Serial.println("ESP32 CRSF UART LISTEN TASK STARTED");
                     CRSF::duplex_set_RX();
@@ -749,8 +750,10 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
  */
 void ICACHE_RAM_ATTR CRSF::updateSwitchValues()
 {
-    for(int i=0; i<N_SWITCHES; i++) {
-        currentSwitches[i] = ChannelDataIn[i+4] / 682; // input is 0 - 2048, output is 0 - 2
+    #define INPUT_RANGE 2048
+    const uint16_t SWITCH_DIVISOR = INPUT_RANGE / 3; // input is 0 - 2048
+    for(int i = 0; i < N_SWITCHES; i++) {
+        currentSwitches[i] = ChannelDataIn[i + 4] / SWITCH_DIVISOR;
     }
 }
 

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -269,6 +269,9 @@ static inline uint16_t ICACHE_RAM_ATTR UINT10_to_CRSF(uint16_t Val) { return rou
 
 static inline uint16_t ICACHE_RAM_ATTR SWITCH3b_to_CRSF(uint16_t Val) { return round(map(Val, 0, 7, 188, 1795)); };
 
+// 2b switches use 0, 1 and 2 as values to represent low, middle and high
+static inline uint16_t ICACHE_RAM_ATTR SWITCH2b_to_CRSF(uint16_t Val) { return round(map(Val, 0, 2, 188, 1795)); };
+
 static inline uint8_t ICACHE_RAM_ATTR CRSF_to_BIT(uint16_t Val)
 {
     if (Val > 1000)
@@ -357,6 +360,14 @@ public:
     static volatile uint16_t ChannelDataInPrev[16]; // Contains the previous RC channel data
     static volatile uint16_t ChannelDataOut[16];
 
+    // current and sent switch values
+    #define N_SWITCHES 8
+
+    static uint8_t currentSwitches[N_SWITCHES];
+    static uint8_t sentSwitches[N_SWITCHES];
+    // which switch should be sent in the next rc packet
+    static uint8_t nextSwitchIndex;
+
     static void (*RCdataCallback1)(); //function pointer for new RC data callback
     static void (*RCdataCallback2)(); //function pointer for new RC data callback
 
@@ -415,6 +426,7 @@ public:
     static void ICACHE_RAM_ATTR STM32handleUARTout();
 #endif
 
+
     void ICACHE_RAM_ATTR sendRCFrameToFC();
     void ICACHE_RAM_ATTR sendLinkStatisticsToFC();
     void ICACHE_RAM_ATTR sendLinkStatisticsToTX();
@@ -423,6 +435,9 @@ public:
     void ICACHE_RAM_ATTR sendLUAresponse(uint8_t val1, uint8_t val2, uint8_t val3, uint8_t val4);
 
     static void ICACHE_RAM_ATTR sendSetVTXchannel(uint8_t band, uint8_t channel);
+
+    uint8_t ICACHE_RAM_ATTR getNextSwitchIndex();
+    void ICACHE_RAM_ATTR setSentSwitch(uint8_t index, uint8_t value);
 
 ///// Variables for OpenTX Syncing //////////////////////////
 #define OpenTXsyncPakcetInterval 100 // in ms
@@ -438,6 +453,7 @@ public:
     static void ICACHE_RAM_ATTR ESP32ProcessPacket();
     static bool ICACHE_RAM_ATTR STM32ProcessPacket();
     static void ICACHE_RAM_ATTR GetChannelDataIn();
+    static void ICACHE_RAM_ATTR updateSwitchValues();
 
     static void inline nullCallback(void);
 

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -4,11 +4,11 @@
 
 #include "OTA.h"
 
-#ifdef HYBRID_SWITCHES_8
+#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 
 /**
- * Hybrid switches packet
- * Replaces Generate4ChannelData_11bit
+ * Hybrid switches packet encoding for sending over the air
+ *
  * Analog channels are reduced to 10 bits to allow for switch encoding
  * Switch[0] is sent on every packet.
  * A 3 bit switch index and 2 bit value is used to send the remaining switches
@@ -48,4 +48,136 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(SX127xDriver *Radio, CRSF 
   // update the sent value
   crsf->setSentSwitch(i, value);
 }
-#endif
+
+/**
+ * Hybrid switches decoding of over the air data
+ *
+ * Hybrid switches uses 10 bits for each analog channel,
+ * 2 bits for the low latency switch[0]
+ * 3 bits for the round-robin switch index and 2 bits for the value
+ *
+ * Input: Radio->RXdataBuffer
+ * Output: crsf->PackedRCdataOut
+ */
+void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitches8(SX127xDriver *Radio, CRSF *crsf)
+{
+    // The analog channels
+    crsf->PackedRCdataOut.ch0 = (Radio->RXdataBuffer[1] << 3) + ((Radio->RXdataBuffer[5] & 0b11000000) >> 5);
+    crsf->PackedRCdataOut.ch1 = (Radio->RXdataBuffer[2] << 3) + ((Radio->RXdataBuffer[5] & 0b00110000) >> 3);
+    crsf->PackedRCdataOut.ch2 = (Radio->RXdataBuffer[3] << 3) + ((Radio->RXdataBuffer[5] & 0b00001100) >> 1);
+    crsf->PackedRCdataOut.ch3 = (Radio->RXdataBuffer[4] << 3) + ((Radio->RXdataBuffer[5] & 0b00000011) << 1);
+
+    // The low latency switch
+    crsf->PackedRCdataOut.ch4 = SWITCH2b_to_CRSF((Radio->RXdataBuffer[6] & 0b01100000) >> 5);
+
+    // The round-robin switch
+    uint8_t switchIndex = (Radio->RXdataBuffer[6] & 0b11100) >> 2;
+    uint16_t switchValue = SWITCH2b_to_CRSF(Radio->RXdataBuffer[6] & 0b11);
+
+    switch (switchIndex) {
+        case 0:   // we should never get index 0 here since that is the low latency switch
+            Serial.println("BAD switchIndex 0");
+            break;
+        case 1:
+            crsf->PackedRCdataOut.ch5 = switchValue;
+            break;
+        case 2:
+            crsf->PackedRCdataOut.ch6 = switchValue;
+            break;
+        case 3:
+            crsf->PackedRCdataOut.ch7 = switchValue;
+            break;
+        case 4:
+            crsf->PackedRCdataOut.ch8 = switchValue;
+            break;
+        case 5:
+            crsf->PackedRCdataOut.ch9 = switchValue;
+            break;
+        case 6:
+            crsf->PackedRCdataOut.ch10 = switchValue;
+            break;
+        case 7:
+            crsf->PackedRCdataOut.ch11 = switchValue;
+            break;
+    }
+}
+
+#endif // HYBRID_SWITCHES_8
+
+#if defined SEQ_SWITCHES or defined UNIT_TEST
+
+/**
+ * Sequential switches packet encoding
+ *
+ * Channel 3 is reduced to 10 bits to allow a 3 bit switch index and 2 bit value
+ * We cycle through 8 switches on successive packets. If any switches have changed
+ * we take the lowest indexed one and send that, hence lower indexed switches have
+ * higher priority in the event that several are changed at once.
+ */
+void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(SX127xDriver *Radio, CRSF *crsf, uint8_t addr)
+{
+  uint8_t PacketHeaderAddr;
+  PacketHeaderAddr = (addr << 2) + RC_DATA_PACKET;
+  Radio->TXdataBuffer[0] = PacketHeaderAddr;
+  Radio->TXdataBuffer[1] = ((crsf->ChannelDataIn[0]) >> 3);
+  Radio->TXdataBuffer[2] = ((crsf->ChannelDataIn[1]) >> 3);
+  Radio->TXdataBuffer[3] = ((crsf->ChannelDataIn[2]) >> 3);
+  Radio->TXdataBuffer[4] = ((crsf->ChannelDataIn[3]) >> 3);
+  Radio->TXdataBuffer[5] = ((crsf->ChannelDataIn[0] & 0b00000111) << 5) + ((crsf->ChannelDataIn[1] & 0b111) << 2) + ((crsf->ChannelDataIn[2] & 0b110) >> 1);
+  Radio->TXdataBuffer[6] = ((crsf->ChannelDataIn[2] & 0b001) << 7) + ((crsf->ChannelDataIn[3] & 0b110) << 4);
+
+  // find the next switch to send
+  uint8_t i = crsf->getNextSwitchIndex() & 0b111; // mask for paranoia
+  uint8_t value = crsf->currentSwitches[i] & 0b11; // mask for paranoia
+
+  // put the bits into buf[6]
+  Radio->TXdataBuffer[6] += (i << 2) + value;
+
+  // update the sent value
+  crsf->setSentSwitch(i, value);
+}
+
+
+/**
+ * Sequential switches decoding of over the air packet
+ *
+ * Seq switches uses 10 bits for ch3, 3 bits for the switch index and 2 bits for the switch value
+ */
+void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitches(SX127xDriver *Radio, CRSF *crsf)
+{
+    crsf->PackedRCdataOut.ch0 = (Radio->RXdataBuffer[1] << 3) + ((Radio->RXdataBuffer[5] & 0b11100000) >> 5);
+    crsf->PackedRCdataOut.ch1 = (Radio->RXdataBuffer[2] << 3) + ((Radio->RXdataBuffer[5] & 0b00011100) >> 2);
+    crsf->PackedRCdataOut.ch2 = (Radio->RXdataBuffer[3] << 3) + ((Radio->RXdataBuffer[5] & 0b00000011) << 1) + (Radio->RXdataBuffer[6] & 0b10000000 >> 7);
+    crsf->PackedRCdataOut.ch3 = (Radio->RXdataBuffer[4] << 3) + ((Radio->RXdataBuffer[6] & 0b01100000) >> 4);
+
+    uint8_t switchIndex = (Radio->RXdataBuffer[6] & 0b11100) >> 2;
+    uint16_t switchValue = SWITCH2b_to_CRSF(Radio->RXdataBuffer[6] & 0b11);
+
+    switch (switchIndex) {
+        case 0:
+            crsf->PackedRCdataOut.ch4 = switchValue;
+            break;
+        case 1:
+            crsf->PackedRCdataOut.ch5 = switchValue;
+            break;
+        case 2:
+            crsf->PackedRCdataOut.ch6 = switchValue;
+            break;
+        case 3:
+            crsf->PackedRCdataOut.ch7 = switchValue;
+            break;
+        case 4:
+            crsf->PackedRCdataOut.ch8 = switchValue;
+            break;
+        case 5:
+            crsf->PackedRCdataOut.ch9 = switchValue;
+            break;
+        case 6:
+            crsf->PackedRCdataOut.ch10 = switchValue;
+            break;
+        case 7:
+            crsf->PackedRCdataOut.ch11 = switchValue;
+            break;
+    }
+}
+#endif // SEQ_SWITCHES

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -1,5 +1,9 @@
 /**
- * TODO - add header
+ * This file is part of ExpressLRS
+ * See https://github.com/AlessandroAU/ExpressLRS
+ *
+ * This file provides utilities for packing and unpacking the data to
+ * be sent over the radio link.
  */
 
 #include "OTA.h"
@@ -38,15 +42,15 @@ void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(SX127xDriver *Radio, CRSF 
   Radio->TXdataBuffer[6] = (crsf->currentSwitches[0] & 0b11) << 5; // note this leaves the top bit of byte 6 unused
 
   // find the next switch to send
-  int i = crsf->getNextSwitchIndex() & 0b111;      // mask for paranoia
-  uint8_t value = crsf->currentSwitches[i] & 0b11; // mask for paranoia
+  uint8_t nextSwitchIndex = crsf->getNextSwitchIndex() & 0b111;      // mask for paranoia
+  uint8_t value = crsf->currentSwitches[nextSwitchIndex] & 0b11; // mask for paranoia
 
-  // put the bits into buf[6]-> i is in the range 1 through 7 so takes 3 bits
-  // currentSwitches[i] is in the range 0 through 2, takes 2 bits->
-  Radio->TXdataBuffer[6] += (i << 2) + value;
+  // put the bits into buf[6]. nextSwitchIndex is in the range 1 through 7 so takes 3 bits
+  // currentSwitches[nextSwitchIndex] is in the range 0 through 2, takes 2 bits.
+  Radio->TXdataBuffer[6] += (nextSwitchIndex << 2) + value;
 
   // update the sent value
-  crsf->setSentSwitch(i, value);
+  crsf->setSentSwitch(nextSwitchIndex, value);
 }
 
 /**
@@ -127,16 +131,15 @@ void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(SX127xDriver *Radio, CRSF *crs
   Radio->TXdataBuffer[6] = ((crsf->ChannelDataIn[2] & 0b001) << 7) + ((crsf->ChannelDataIn[3] & 0b110) << 4);
 
   // find the next switch to send
-  uint8_t i = crsf->getNextSwitchIndex() & 0b111; // mask for paranoia
-  uint8_t value = crsf->currentSwitches[i] & 0b11; // mask for paranoia
+  uint8_t nextSwitchIndex = crsf->getNextSwitchIndex() & 0b111; // mask for paranoia
+  uint8_t value = crsf->currentSwitches[nextSwitchIndex] & 0b11; // mask for paranoia
 
   // put the bits into buf[6]
-  Radio->TXdataBuffer[6] += (i << 2) + value;
+  Radio->TXdataBuffer[6] += (nextSwitchIndex << 2) + value;
 
   // update the sent value
-  crsf->setSentSwitch(i, value);
+  crsf->setSentSwitch(nextSwitchIndex, value);
 }
-
 
 /**
  * Sequential switches decoding of over the air packet

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -1,5 +1,7 @@
-#include "CRSF.h"
-#include "LoRaRadioLib.h"
+/**
+ * TODO - add header
+ */
+
 #include "OTA.h"
 
 #ifdef HYBRID_SWITCHES_8

--- a/src/lib/OTA/OTA.cpp
+++ b/src/lib/OTA/OTA.cpp
@@ -1,0 +1,49 @@
+#include "CRSF.h"
+#include "LoRaRadioLib.h"
+#include "OTA.h"
+
+#ifdef HYBRID_SWITCHES_8
+
+/**
+ * Hybrid switches packet
+ * Replaces Generate4ChannelData_11bit
+ * Analog channels are reduced to 10 bits to allow for switch encoding
+ * Switch[0] is sent on every packet.
+ * A 3 bit switch index and 2 bit value is used to send the remaining switches
+ * in a round-robin fashion.
+ * If any of the round-robin switches have changed
+ * we take the lowest indexed one and send that, hence lower indexed switches have
+ * higher priority in the event that several are changed at once.
+ * 
+ * Inputs: crsf.ChannelDataIn, crsf.currentSwitches
+ * Outputs: Radio.TXdataBuffer, side-effects the sentSwitch value
+ */
+void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8(SX127xDriver *Radio, CRSF *crsf, uint8_t addr)
+{
+  uint8_t PacketHeaderAddr;
+  PacketHeaderAddr = (addr << 2) + RC_DATA_PACKET;
+  Radio->TXdataBuffer[0] = PacketHeaderAddr;
+  Radio->TXdataBuffer[1] = ((crsf->ChannelDataIn[0]) >> 3);
+  Radio->TXdataBuffer[2] = ((crsf->ChannelDataIn[1]) >> 3);
+  Radio->TXdataBuffer[3] = ((crsf->ChannelDataIn[2]) >> 3);
+  Radio->TXdataBuffer[4] = ((crsf->ChannelDataIn[3]) >> 3);
+  Radio->TXdataBuffer[5] = ((crsf->ChannelDataIn[0] & 0b110) << 5) + 
+                           ((crsf->ChannelDataIn[1] & 0b110) << 3) +
+                           ((crsf->ChannelDataIn[2] & 0b110) << 1) + 
+                           ((crsf->ChannelDataIn[3] & 0b110) >> 1);
+
+  // switch 0 is sent on every packet - intended for low latency arm/disarm
+  Radio->TXdataBuffer[6] = (crsf->currentSwitches[0] & 0b11) << 5; // note this leaves the top bit of byte 6 unused
+
+  // find the next switch to send
+  int i = crsf->getNextSwitchIndex() & 0b111;      // mask for paranoia
+  uint8_t value = crsf->currentSwitches[i] & 0b11; // mask for paranoia
+
+  // put the bits into buf[6]-> i is in the range 1 through 7 so takes 3 bits
+  // currentSwitches[i] is in the range 0 through 2, takes 2 bits->
+  Radio->TXdataBuffer[6] += (i << 2) + value;
+
+  // update the sent value
+  crsf->setSentSwitch(i, value);
+}
+#endif

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -1,8 +1,8 @@
 #ifndef H_OTA
 #define H_OTA
 
+#include "LoRaRadioLib.h" // this has to come before CRSF.h when compiling on R9
 #include "CRSF.h"
-#include "LoRaRadioLib.h"
 
 // expresslrs packet header types
 // 00 -> standard 4 channel data packet

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -14,8 +14,19 @@
 #define TLM_PACKET 0b11
 #define SYNC_PACKET 0b10
 
-#ifdef HYBRID_SWITCHES_8
-void GenerateChannelDataHybridSwitch8(SX127xDriver *Radio, CRSF *crsf, uint8_t addr);
-#endif
+#if defined HYBRID_SWITCHES_8 or defined UNIT_TEST
 
-#endif
+void GenerateChannelDataHybridSwitch8(SX127xDriver *Radio, CRSF *crsf, uint8_t addr);
+void UnpackChannelDataHybridSwitches8(SX127xDriver *Radio, CRSF *crsf);
+
+#endif // HYBRID_SWITCHES_8
+
+#if defined SEQ_SWITCHES or defined UNIT_TEST
+
+void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch(SX127xDriver *Radio, CRSF *crsf, uint8_t addr);
+void UnpackChannelDataSeqSwitches(SX127xDriver *Radio, CRSF *crsf);
+
+#endif // SEQ_SWITCHES
+
+
+#endif // H_OTA

--- a/src/lib/OTA/OTA.h
+++ b/src/lib/OTA/OTA.h
@@ -1,0 +1,21 @@
+#ifndef H_OTA
+#define H_OTA
+
+#include "CRSF.h"
+#include "LoRaRadioLib.h"
+
+// expresslrs packet header types
+// 00 -> standard 4 channel data packet
+// 01 -> switch data packet
+// 11 -> tlm packet
+// 10 -> sync packet with hop data
+#define RC_DATA_PACKET 0b00
+#define SWITCH_DATA_PACKET 0b01
+#define TLM_PACKET 0b11
+#define SYNC_PACKET 0b10
+
+#ifdef HYBRID_SWITCHES_8
+void GenerateChannelDataHybridSwitch8(SX127xDriver *Radio, CRSF *crsf, uint8_t addr);
+#endif
+
+#endif

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -92,12 +92,3 @@ int16_t MeasureRSSI(int FHSSindex); //--todo, move this to radio lib
 
 uint8_t TLMratioEnumToValue(expresslrs_tlm_ratio_e enumval);
 
-// expresslrs packet header types
-// 00 -> standard 4 channel data packet
-// 01 -> switch data packet
-// 11 -> tlm packet
-// 10 -> sync packet with hop data
-#define RC_DATA_PACKET 0b00
-#define SWITCH_DATA_PACKET 0b01
-#define TLM_PACKET 0b11
-#define SYNC_PACKET 0b10

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -237,6 +237,100 @@ void ICACHE_RAM_ATTR UnpackChannelData_11bit()
 #endif
 }
 
+#ifdef SEQ_SWITCHES
+/**
+ * Seq switches uses 10 bits for ch3, 3 bits for the switch index and 2 bits for the switch value
+ */
+void ICACHE_RAM_ATTR UnpackChannelDataSeqSwitches()
+{
+    crsf.PackedRCdataOut.ch0 = (Radio.RXdataBuffer[1] << 3) + ((Radio.RXdataBuffer[5] & 0b11100000) >> 5);
+    crsf.PackedRCdataOut.ch1 = (Radio.RXdataBuffer[2] << 3) + ((Radio.RXdataBuffer[5] & 0b00011100) >> 2);
+    crsf.PackedRCdataOut.ch2 = (Radio.RXdataBuffer[3] << 3) + ((Radio.RXdataBuffer[5] & 0b00000011) << 1) + (Radio.RXdataBuffer[6] & 0b10000000 >> 7);
+    crsf.PackedRCdataOut.ch3 = (Radio.RXdataBuffer[4] << 3) + ((Radio.RXdataBuffer[6] & 0b01100000) >> 4);
+
+    uint8_t switchIndex = (Radio.RXdataBuffer[6] & 0b11100) >> 2;
+    uint16_t switchValue = SWITCH2b_to_CRSF(Radio.RXdataBuffer[6] & 0b11);
+
+    switch (switchIndex) {
+        case 0:
+            crsf.PackedRCdataOut.ch4 = switchValue;
+            break;
+        case 1:
+            crsf.PackedRCdataOut.ch5 = switchValue;
+            break;
+        case 2:
+            crsf.PackedRCdataOut.ch6 = switchValue;
+            break;
+        case 3:
+            crsf.PackedRCdataOut.ch7 = switchValue;
+            break;
+        case 4:
+            crsf.PackedRCdataOut.ch8 = switchValue;
+            break;
+        case 5:
+            crsf.PackedRCdataOut.ch9 = switchValue;
+            break;
+        case 6:
+            crsf.PackedRCdataOut.ch10 = switchValue;
+            break;
+        case 7:
+            crsf.PackedRCdataOut.ch11 = switchValue;
+            break;
+    }
+}
+#endif
+
+#ifdef HYBRID_SWITCHES_8
+/**
+ * Hybrid switches uses 10 bits for each analog channel, 
+ * 2 bits for the low latency switch[0]
+ * 3 bits for the round-robin switch index and 2 bits for the value
+ */
+void ICACHE_RAM_ATTR UnpackChannelDataHybridSwitches8()
+{
+    // The analog channels
+    crsf.PackedRCdataOut.ch0 = (Radio.RXdataBuffer[1] << 3) + ((Radio.RXdataBuffer[5] & 0b11000000) >> 5);
+    crsf.PackedRCdataOut.ch1 = (Radio.RXdataBuffer[2] << 3) + ((Radio.RXdataBuffer[5] & 0b00110000) >> 3);
+    crsf.PackedRCdataOut.ch2 = (Radio.RXdataBuffer[3] << 3) + ((Radio.RXdataBuffer[5] & 0b00001100) >> 1);
+    crsf.PackedRCdataOut.ch3 = (Radio.RXdataBuffer[4] << 3) + ((Radio.RXdataBuffer[5] & 0b00000011) << 1);
+
+    // The low latency switch
+    crsf.PackedRCdataOut.ch4 = SWITCH2b_to_CRSF((Radio.RXdataBuffer[6] & 0b01100000) >> 5);
+
+    // The round-robin switch
+    uint8_t switchIndex = (Radio.RXdataBuffer[6] & 0b11100) >> 2;
+    uint16_t switchValue = SWITCH2b_to_CRSF(Radio.RXdataBuffer[6] & 0b11);
+
+    switch (switchIndex) {
+        case 0:   // we should never get index 0 here since that is the low latency switch
+            Serial.println("BAD switchIndex 0");
+            break;
+        case 1:
+            crsf.PackedRCdataOut.ch5 = switchValue;
+            break;
+        case 2:
+            crsf.PackedRCdataOut.ch6 = switchValue;
+            break;
+        case 3:
+            crsf.PackedRCdataOut.ch7 = switchValue;
+            break;
+        case 4:
+            crsf.PackedRCdataOut.ch8 = switchValue;
+            break;
+        case 5:
+            crsf.PackedRCdataOut.ch9 = switchValue;
+            break;
+        case 6:
+            crsf.PackedRCdataOut.ch10 = switchValue;
+            break;
+        case 7:
+            crsf.PackedRCdataOut.ch11 = switchValue;
+            break;
+    }
+}
+#endif
+
+
 void ICACHE_RAM_ATTR UnpackChannelData_10bit()
 {
     crsf.PackedRCdataOut.ch0 = UINT10_to_CRSF((Radio.RXdataBuffer[1] << 2) + ((Radio.RXdataBuffer[5] & 0b11000000) >> 6));
@@ -281,7 +375,13 @@ void ICACHE_RAM_ATTR ProcessRFPacket()
     switch (type)
     {
     case RC_DATA_PACKET: //Standard RC Data Packet
+#if defined SEQ_SWITCHES
+        UnpackChannelDataSeqSwitches();
+#elif defined HYBRID_SWITCHES_8
+        UnpackChannelDataHybridSwitches8();
+#else
         UnpackChannelData_11bit();
+#endif
         crsf.sendRCFrameToFC();
         break;
 

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -238,9 +238,6 @@ void ICACHE_RAM_ATTR UnpackChannelData_11bit()
 #endif
 }
 
-
-
-
 void ICACHE_RAM_ATTR UnpackChannelData_10bit()
 {
     crsf.PackedRCdataOut.ch0 = UINT10_to_CRSF((Radio.RXdataBuffer[1] << 2) + ((Radio.RXdataBuffer[5] & 0b11000000) >> 6));

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -9,6 +9,7 @@
 // #include "Debug.h"
 #include "rx_LinkQuality.h"
 #include "errata.h"
+#include "OTA.h"
 
 #ifdef PLATFORM_ESP8266
 #include "ESP8266_WebUpdate.h"

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -11,6 +11,7 @@
 #include "POWERMGNT.h"
 #include "msp.h"
 #include "msptypes.h"
+#include <OTA.h>
 
 #ifdef TARGET_EXPRESSLRS_PCB_TX_V3
 #include "soc/soc.h"
@@ -241,45 +242,6 @@ void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch()
 }
 #endif
 
-#ifdef HYBRID_SWITCHES_8
-/**
- * Hybrid switches packet
- * Replaces Generate4ChannelData_11bit
- * Analog channels are reduced to 10 bits to allow for switch encoding
- * Switch[0] is sent on every packet.
- * A 3 bit switch index and 2 bit value is used to send the remaining switches
- * in a round-robin fashion.
- * If any of the round-robin switches have changed
- * we take the lowest indexed one and send that, hence lower indexed switches have
- * higher priority in the event that several are changed at once.
- */
-void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8()
-{
-  uint8_t PacketHeaderAddr;
-  PacketHeaderAddr = (DeviceAddr << 2) + RC_DATA_PACKET;
-  Radio.TXdataBuffer[0] = PacketHeaderAddr;
-  Radio.TXdataBuffer[1] = ((crsf.ChannelDataIn[0]) >> 3);
-  Radio.TXdataBuffer[2] = ((crsf.ChannelDataIn[1]) >> 3);
-  Radio.TXdataBuffer[3] = ((crsf.ChannelDataIn[2]) >> 3);
-  Radio.TXdataBuffer[4] = ((crsf.ChannelDataIn[3]) >> 3);
-  Radio.TXdataBuffer[5] = ((crsf.ChannelDataIn[0] & 0b110) << 5) + ((crsf.ChannelDataIn[1] & 0b110) << 3) +
-                          ((crsf.ChannelDataIn[2] & 0b110) << 1) + ((crsf.ChannelDataIn[3] & 0b110) >> 1);
-
-  // switch 0 is sent on every packet - intended for low latency arm/disarm
-  Radio.TXdataBuffer[6] = (crsf.currentSwitches[0] & 0b11) << 5; // note this leaves the top bit of byte 6 unused
-
-  // find the next switch to send
-  int i = crsf.getNextSwitchIndex() & 0b111; // mask for paranoia
-  uint8_t value = crsf.currentSwitches[i] & 0b11; // mask for paranoia
-
-  // put the bits into buf[6]. i is in the range 1 through 7 so takes 3 bits
-  // currentSwitches[i] is in the range 0 through 2, takes 2 bits.
-  Radio.TXdataBuffer[6] += (i << 2) + value;
-
-  // update the sent value
-  crsf.setSentSwitch(i, value);
-}
-#endif
 
 void ICACHE_RAM_ATTR GenerateSwitchChannelData()
 {
@@ -416,7 +378,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   else
   {
 #if defined HYBRID_SWITCHES_8
-    GenerateChannelDataHybridSwitch8();
+    GenerateChannelDataHybridSwitch8(&Radio, &crsf, DeviceAddr);
 #elif defined SEQ_SWITCHES
     GenerateChannelDataSeqSwitch();
 #else
@@ -702,6 +664,7 @@ void loop()
   button.handle();
 #endif
 
+<<<<<<< 1b13d02ffb71cc3cadb6d80e9de4f51f4ff71dda
 <<<<<<< 017e1958d86feddb32c14cc2d5c67cd93acd9400
 #ifdef PLATFORM_ESP32
   if (Serial2.available()) {
@@ -719,6 +682,10 @@ void loop()
   }
 =======
 >>>>>>> Sequential and hybrid switch modes
+=======
+  vTaskDelay(2);
+
+>>>>>>> Created OTA lib for packet encoding
 }
 
 void ICACHE_RAM_ATTR TimerExpired()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -664,8 +664,6 @@ void loop()
   button.handle();
 #endif
 
-<<<<<<< 1b13d02ffb71cc3cadb6d80e9de4f51f4ff71dda
-<<<<<<< 017e1958d86feddb32c14cc2d5c67cd93acd9400
 #ifdef PLATFORM_ESP32
   if (Serial2.available()) {
     uint8_t c = Serial2.read();
@@ -680,12 +678,6 @@ void loop()
       msp.markPacketReceived();
     }
   }
-=======
->>>>>>> Sequential and hybrid switch modes
-=======
-  vTaskDelay(2);
-
->>>>>>> Created OTA lib for packet encoding
 }
 
 void ICACHE_RAM_ATTR TimerExpired()

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -208,6 +208,79 @@ void ICACHE_RAM_ATTR Generate4ChannelData_11bit()
 #endif
 }
 
+#ifdef SEQ_SWITCHES
+/**
+ * Sequential switches packet
+ * Replaces Generate4ChannelData_11bit
+ * Channel 3 is reduced to 10 bits to allow a 3 bit switch index and 2 bit value
+ * We cycle through 8 switches on successive packets. If any switches have changed
+ * we take the lowest indexed one and send that, hence lower indexed switches have
+ * higher priority in the event that several are changed at once.
+ */
+void ICACHE_RAM_ATTR GenerateChannelDataSeqSwitch()
+{
+  uint8_t PacketHeaderAddr;
+  PacketHeaderAddr = (DeviceAddr << 2) + RC_DATA_PACKET;
+  Radio.TXdataBuffer[0] = PacketHeaderAddr;
+  Radio.TXdataBuffer[1] = ((crsf.ChannelDataIn[0]) >> 3);
+  Radio.TXdataBuffer[2] = ((crsf.ChannelDataIn[1]) >> 3);
+  Radio.TXdataBuffer[3] = ((crsf.ChannelDataIn[2]) >> 3);
+  Radio.TXdataBuffer[4] = ((crsf.ChannelDataIn[3]) >> 3);
+  Radio.TXdataBuffer[5] = ((crsf.ChannelDataIn[0] & 0b00000111) << 5) + ((crsf.ChannelDataIn[1] & 0b111) << 2) + ((crsf.ChannelDataIn[2] & 0b110) >> 1);
+  Radio.TXdataBuffer[6] = ((crsf.ChannelDataIn[2] & 0b001) << 7) + ((crsf.ChannelDataIn[3] & 0b110) << 4);
+
+  // find the next switch to send
+  uint8_t i = crsf.getNextSwitchIndex() & 0b111; // mask for paranoia
+  uint8_t value = crsf.currentSwitches[i] & 0b11; // mask for paranoia
+
+  // put the bits into buf[6]
+  Radio.TXdataBuffer[6] += (i << 2) + value;
+
+  // update the sent value
+  crsf.setSentSwitch(i, value);
+}
+#endif
+
+#ifdef HYBRID_SWITCHES_8
+/**
+ * Hybrid switches packet
+ * Replaces Generate4ChannelData_11bit
+ * Analog channels are reduced to 10 bits to allow for switch encoding
+ * Switch[0] is sent on every packet.
+ * A 3 bit switch index and 2 bit value is used to send the remaining switches
+ * in a round-robin fashion.
+ * If any of the round-robin switches have changed
+ * we take the lowest indexed one and send that, hence lower indexed switches have
+ * higher priority in the event that several are changed at once.
+ */
+void ICACHE_RAM_ATTR GenerateChannelDataHybridSwitch8()
+{
+  uint8_t PacketHeaderAddr;
+  PacketHeaderAddr = (DeviceAddr << 2) + RC_DATA_PACKET;
+  Radio.TXdataBuffer[0] = PacketHeaderAddr;
+  Radio.TXdataBuffer[1] = ((crsf.ChannelDataIn[0]) >> 3);
+  Radio.TXdataBuffer[2] = ((crsf.ChannelDataIn[1]) >> 3);
+  Radio.TXdataBuffer[3] = ((crsf.ChannelDataIn[2]) >> 3);
+  Radio.TXdataBuffer[4] = ((crsf.ChannelDataIn[3]) >> 3);
+  Radio.TXdataBuffer[5] = ((crsf.ChannelDataIn[0] & 0b110) << 5) + ((crsf.ChannelDataIn[1] & 0b110) << 3) +
+                          ((crsf.ChannelDataIn[2] & 0b110) << 1) + ((crsf.ChannelDataIn[3] & 0b110) >> 1);
+
+  // switch 0 is sent on every packet - intended for low latency arm/disarm
+  Radio.TXdataBuffer[6] = (crsf.currentSwitches[0] & 0b11) << 5; // note this leaves the top bit of byte 6 unused
+
+  // find the next switch to send
+  int i = crsf.getNextSwitchIndex() & 0b111; // mask for paranoia
+  uint8_t value = crsf.currentSwitches[i] & 0b11; // mask for paranoia
+
+  // put the bits into buf[6]. i is in the range 1 through 7 so takes 3 bits
+  // currentSwitches[i] is in the range 0 through 2, takes 2 bits.
+  Radio.TXdataBuffer[6] += (i << 2) + value;
+
+  // update the sent value
+  crsf.setSentSwitch(i, value);
+}
+#endif
+
 void ICACHE_RAM_ATTR GenerateSwitchChannelData()
 {
   uint8_t PacketHeaderAddr;
@@ -342,6 +415,11 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
   }
   else
   {
+#if defined HYBRID_SWITCHES_8
+    GenerateChannelDataHybridSwitch8();
+#elif defined SEQ_SWITCHES
+    GenerateChannelDataSeqSwitch();
+#else
     if ((millis() > (SWITCH_PACKET_SEND_INTERVAL + SwitchPacketLastSent)) || Channels5to8Changed)
     {
       Channels5to8Changed = false;
@@ -352,6 +430,7 @@ void ICACHE_RAM_ATTR SendRCdataToRF()
     {
       Generate4ChannelData_11bit();
     }
+#endif
   }
 
   ///// Next, Calculate the CRC and put it into the buffer /////
@@ -623,6 +702,7 @@ void loop()
   button.handle();
 #endif
 
+<<<<<<< 017e1958d86feddb32c14cc2d5c67cd93acd9400
 #ifdef PLATFORM_ESP32
   if (Serial2.available()) {
     uint8_t c = Serial2.read();
@@ -637,6 +717,8 @@ void loop()
       msp.markPacketReceived();
     }
   }
+=======
+>>>>>>> Sequential and hybrid switch modes
 }
 
 void ICACHE_RAM_ATTR TimerExpired()

--- a/src/test/test_main.cpp
+++ b/src/test/test_main.cpp
@@ -2,6 +2,7 @@
 #include <unity.h>
 #include "mock_serial.h"
 #include "msp_tests.h"
+#include "test_switches.h"
 
 void setup() {
     // NOTE!!! Wait for >2 secs
@@ -12,6 +13,8 @@ void setup() {
 
     RUN_TEST(test_msp_receive);
     RUN_TEST(test_msp_send);
+
+    setup_switches();
 }
 
 void loop() {

--- a/src/test/test_switches.cpp
+++ b/src/test/test_switches.cpp
@@ -276,7 +276,6 @@ void test_decodingSEQ()
 
     // copy into the required buffer for the decoder
     memcpy((void*)Radio.RXdataBuffer, (const void*)Radio.TXdataBuffer, sizeof(Radio.RXdataBuffer));
-    for(int i=0;i<8; i++) Serial.printf("%d %d\n", Radio.RXdataBuffer[i], Radio.TXdataBuffer[i]);
 
     // clear the output buffer to avoid cross-talk between tests
     memset((void *) &crsf.PackedRCdataOut, 0, sizeof(crsf.PackedRCdataOut));

--- a/src/test/test_switches.cpp
+++ b/src/test/test_switches.cpp
@@ -1,15 +1,30 @@
+/**
+ * This file is part of ExpressLRS
+ * See https://github.com/AlessandroAU/ExpressLRS
+ *
+ * Unit tests for over the air packet encoding, decoding and associated utilities
+ *
+ * Entry point is setup_switches()
+ */
+
 #include <Arduino.h>
 #include <unity.h>
 
-#include "CRSF.h"
 #include "LoRaRadioLib.h"
+#include "CRSF.h"       // has to come after LoraRadioLib.h for R9
 #include "targets.h"
 #include "common.h"
 #include <OTA.h>
 
-CRSF crsf;  // need an instance to provide the fields and code to be tested
-SX127xDriver Radio; // needed for Radio.TXdataBuffer
+// Tests have only been run on TTGO V1, so we have to guard
+// all the testcode to prevent breakages until it's know to do
+// something sensible.
 
+#ifdef TARGET_TTGO_LORA_V1_AS_TX
+
+CRSF crsf;  // need an instance to provide the fields used by the code under test
+
+SX127xDriver Radio; // needed for Radio.TXdataBuffer
 
 /* Check that the round robin works
  * First call should return 0 for seq switches or 1 for hybrid
@@ -73,9 +88,12 @@ void test_priority(void) {
 
 }
 
-/* Check the encoding of a packet for OTA tx
+// ------------------------------------------------
+// Test the hybrid8 encoding/decoding
+
+/* Check the hybrid 8 encoding of a packet for OTA tx
 */
-void test_encoding()
+void test_encodingHybrid8()
 {
     uint8_t UID[6] = {MY_UID};
     uint8_t DeviceAddr = UID[5] & 0b111111;
@@ -128,10 +146,171 @@ void test_encoding()
 
 /* Check the decoding of a packet after rx
 */
+void test_decodingHybrid8()
+{
+    uint8_t UID[6] = {MY_UID};
+    uint8_t DeviceAddr = UID[5] & 0b111111;
+    // uint8_t expected;
+
+    // Define the input data
+    // 4 channels of analog data
+    crsf.ChannelDataIn[0] = 0x0123;
+    crsf.ChannelDataIn[1] = 0x4567;
+    crsf.ChannelDataIn[2] = 0x89AB;
+    crsf.ChannelDataIn[3] = 0xCDEF;
+
+    // 8 switches
+    for(int i=0; i<N_SWITCHES; i++) {
+        crsf.currentSwitches[i] =  i % 3;
+        crsf.sentSwitches[i] = i % 3; // make all the sent values match
+    }
+
+    // set the nextSwitchIndex so we know which switch to expect in the packet
+    crsf.nextSwitchIndex=3;
+
+    // use the encoding method to pack it into Radio.TXdataBuffer
+    GenerateChannelDataHybridSwitch8(&Radio, &crsf, DeviceAddr);
+
+    // copy into the expected buffer for the decoder
+    memcpy((void*)Radio.RXdataBuffer, (const void*)Radio.TXdataBuffer, sizeof(Radio.RXdataBuffer));
+
+    // run the decoder, results in crsf->PackedRCdataOut
+    UnpackChannelDataHybridSwitches8(&Radio, &crsf);
+
+    // compare the unpacked results with the input data
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[0] & 0b11111111110, crsf.PackedRCdataOut.ch0); // analog channels are truncated to 10 bits
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[1] & 0b11111111110, crsf.PackedRCdataOut.ch1); // analog channels are truncated to 10 bits
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[2] & 0b11111111110, crsf.PackedRCdataOut.ch2); // analog channels are truncated to 10 bits
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[3] & 0b11111111110, crsf.PackedRCdataOut.ch3); // analog channels are truncated to 10 bits
+
+    TEST_ASSERT_EQUAL(SWITCH2b_to_CRSF(crsf.currentSwitches[0] & 0b11), crsf.PackedRCdataOut.ch4); // Switch 0 is sent on every packet
+    TEST_ASSERT_EQUAL(SWITCH2b_to_CRSF(crsf.currentSwitches[3] & 0b11), crsf.PackedRCdataOut.ch7); // We forced switch 3 to be sent as the sequential field
+}
+
+
+// ------------------------------------------------------
+// Test the sequential switches encoding/decoding
+
+// encoding
+void test_encodingSEQ()
+{
+    uint8_t UID[6] = {MY_UID};
+    uint8_t DeviceAddr = UID[5] & 0b111111;
+    uint8_t expected;
+
+    // Define the input data
+    // 4 channels of analog data
+    crsf.ChannelDataIn[0] = 0x0123;
+    crsf.ChannelDataIn[1] = 0x4567;
+    crsf.ChannelDataIn[2] = 0x89AB;
+    crsf.ChannelDataIn[3] = 0xCDEF;
+
+    // 8 switches
+    for(int i=0; i<N_SWITCHES; i++) {
+        crsf.currentSwitches[i] =  i % 3;
+        crsf.sentSwitches[i] = i % 3; // make all the sent values match
+    }
+
+    // set the nextSwitchIndex so we know which switch to expect in the packet
+    crsf.nextSwitchIndex=3;
+
+    // encode it
+    GenerateChannelDataSeqSwitch(&Radio, &crsf, DeviceAddr);
+
+    // check it looks right
+    // 1st byte is header & packet type
+    uint8_t header = (DeviceAddr << 2) + RC_DATA_PACKET;
+    TEST_ASSERT_EQUAL(header, Radio.TXdataBuffer[0]);
+
+    // bytes 1 through 4 are the high bits of the analog channels
+    for(int i=0; i<4; i++) {
+        expected = crsf.ChannelDataIn[i] >> 3; // most significant 8 bits
+        TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[i+1]);
+    }
+
+    // byte 5 contains some bits from the first three channels
+    expected = (crsf.ChannelDataIn[0] & 0b111) << 5 | (crsf.ChannelDataIn[1] & 0b111) << 2 | (crsf.ChannelDataIn[2] & 0b110) >> 1;
+    TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[5]);
+
+    // bit 7 of byte 6 contains the lsb of ChannelDataIn[2], 
+    expected = crsf.ChannelDataIn[2] & 0b1;
+    TEST_ASSERT_EQUAL(expected, (Radio.TXdataBuffer[6] & 0b10000000) >> 7);
+
+    // bits 6,5 contain bits 1,2 of ChannelDataIn[3]
+    expected = (crsf.ChannelDataIn[3] & 0b110) >> 1;
+    TEST_ASSERT_EQUAL(expected, (Radio.TXdataBuffer[6] & 0b1100000) >> 5);
+
+    // the sequential switch bits:
+    // expect index in 2-4 and value in 0,1
+    TEST_ASSERT_EQUAL(3, (Radio.TXdataBuffer[6] & 0b11100)>>2);
+    TEST_ASSERT_EQUAL(crsf.currentSwitches[3], Radio.TXdataBuffer[6] & 0b11);
+}
+
+// decoding
+/* Check the decoding of a packet after rx
+*/
+void test_decodingSEQ()
+{
+    uint8_t UID[6] = {MY_UID};
+    uint8_t DeviceAddr = UID[5] & 0b111111;
+    // uint8_t expected;
+
+    // Define the input data
+    // 4 channels of analog data
+    crsf.ChannelDataIn[0] = 0x0123;
+    crsf.ChannelDataIn[1] = 0x4567;
+    crsf.ChannelDataIn[2] = 0x89AB;
+    crsf.ChannelDataIn[3] = 0xCDEF;
+
+    // 8 switches
+    for(int i=0; i<N_SWITCHES; i++) {
+        crsf.currentSwitches[i] =  (i+1) % 3;
+        crsf.sentSwitches[i] = (i+1) % 3; // make all the sent values match
+    }
+
+    // set the nextSwitchIndex so we know which switch to expect in the packet
+    crsf.nextSwitchIndex=3;
+
+    // use the encoding method to pack it into Radio.TXdataBuffer
+    GenerateChannelDataSeqSwitch(&Radio, &crsf, DeviceAddr);
+
+    // copy into the required buffer for the decoder
+    memcpy((void*)Radio.RXdataBuffer, (const void*)Radio.TXdataBuffer, sizeof(Radio.RXdataBuffer));
+    for(int i=0;i<8; i++) Serial.printf("%d %d\n", Radio.RXdataBuffer[i], Radio.TXdataBuffer[i]);
+
+    // clear the output buffer to avoid cross-talk between tests
+    memset((void *) &crsf.PackedRCdataOut, 0, sizeof(crsf.PackedRCdataOut));
+
+    // run the decoder, results in crsf->PackedRCdataOut
+    UnpackChannelDataSeqSwitches(&Radio, &crsf);
+
+    // compare the unpacked results with the input data
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[0] & 0b11111111111, crsf.PackedRCdataOut.ch0); // contains 11 bit data
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[1] & 0b11111111111, crsf.PackedRCdataOut.ch1); // contains 11 bit data
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[2] & 0b11111111111, crsf.PackedRCdataOut.ch2); // contains 11 bit data
+    TEST_ASSERT_EQUAL(crsf.ChannelDataIn[3] & 0b11111111110, crsf.PackedRCdataOut.ch3); // last analog channel is truncated to 10 bits
+
+    TEST_ASSERT_EQUAL(SWITCH2b_to_CRSF(crsf.currentSwitches[3] & 0b11), crsf.PackedRCdataOut.ch7); // We forced switch 3 to be sent as the sequential field
+}
+
+
+#endif // TARGET_TTGO_LORA_V1_AS_TX
 
 void setup_switches()
 {
+    // tests have only been run on ttgo v1
+    #ifdef TARGET_TTGO_LORA_V1_AS_TX
+
     RUN_TEST(test_round_robin);
     RUN_TEST(test_priority);
-    RUN_TEST(test_encoding);
+
+    // #ifdef HYBRID_SWITCHES_8
+    RUN_TEST(test_encodingHybrid8);
+    RUN_TEST(test_decodingHybrid8);
+    // #endif // HYBRID_SWITCHES_8
+
+    RUN_TEST(test_encodingSEQ);
+    RUN_TEST(test_decodingSEQ);
+
+    #endif // TARGET_TTGO_LORA_V1_AS_TX
 }

--- a/src/test/test_switches.cpp
+++ b/src/test/test_switches.cpp
@@ -31,34 +31,34 @@ SX127xDriver Radio; // needed for Radio.TXdataBuffer
  * Successive calls should increment the next index until wrap
  * around from 7 to either 0 or 1 depending on mode.
  */
-void test_round_robin(void) {
+void test_round_robin(void) 
+{
+    uint8_t expectedIndex = crsf.nextSwitchIndex;
 
-    uint8_t expectedIndex=crsf.nextSwitchIndex;
-
-    for(uint8_t i=0; i<10; i++) {
+    for(uint8_t i = 0; i < 10; i++) {
         uint8_t nsi = crsf.getNextSwitchIndex();
         TEST_ASSERT_EQUAL(expectedIndex, nsi);
         expectedIndex++;
         if (expectedIndex == 8) {
-#ifdef HYBRID_SWITCHES_8
+            #ifdef HYBRID_SWITCHES_8
             expectedIndex = 1;
-#else
+            #else
             expectedIndex = 0;
-#endif
+            #endif
         }
     }
 }
 
 /* Check that a changed switch gets priority
 */
-void test_priority(void) {
-
+void test_priority(void)
+{
     uint8_t nsi;
 
-    crsf.nextSwitchIndex=0; // this would be the next switch if nothing changed
+    crsf.nextSwitchIndex = 0; // this would be the next switch if nothing changed
 
     // set all switches and sent values to be equal
-    for(uint8_t i=0; i<N_SWITCHES; i++) {
+    for(uint8_t i = 0; i < N_SWITCHES; i++) {
         crsf.sentSwitches[i] = 0;
         crsf.currentSwitches[i] = 0;
     }
@@ -85,7 +85,6 @@ void test_priority(void) {
     // to get the last returned value +1
     nsi = crsf.getNextSwitchIndex();
     TEST_ASSERT_EQUAL(7, nsi);
-
 }
 
 // ------------------------------------------------
@@ -107,13 +106,13 @@ void test_encodingHybrid8()
     crsf.ChannelDataIn[3] = 0xCDEF;
 
     // 8 switches
-    for(int i=0; i<N_SWITCHES; i++) {
+    for(int i = 0; i < N_SWITCHES; i++) {
         crsf.currentSwitches[i] =  i % 3;
         crsf.sentSwitches[i] = i % 3; // make all the sent values match
     }
 
     // set the nextSwitchIndex so we know which switch to expect in the packet
-    crsf.nextSwitchIndex=3;
+    crsf.nextSwitchIndex = 3;
 
     // encode it
     GenerateChannelDataHybridSwitch8(&Radio, &crsf, DeviceAddr);
@@ -124,14 +123,14 @@ void test_encodingHybrid8()
     TEST_ASSERT_EQUAL(header, Radio.TXdataBuffer[0]);
 
     // bytes 1 through 5 are 10 bit packed analog channels
-    for(int i=0; i<4; i++) {
+    for(int i = 0; i < 4; i++) {
         expected = crsf.ChannelDataIn[i] >> 3; // most significant 8 bits
-        TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[i+1]);
+        TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[i + 1]);
     }
 
     // byte 5 is bits 1 and 2 of each analog channel
     expected = 0;
-    for(int i=0; i<4; i++) {
+    for(int i = 0; i < 4; i++) {
         expected = (expected <<2) | ((crsf.ChannelDataIn[i] >> 1) & 0b11);
     }
     TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[5]);
@@ -160,13 +159,13 @@ void test_decodingHybrid8()
     crsf.ChannelDataIn[3] = 0xCDEF;
 
     // 8 switches
-    for(int i=0; i<N_SWITCHES; i++) {
+    for(int i = 0; i < N_SWITCHES; i++) {
         crsf.currentSwitches[i] =  i % 3;
         crsf.sentSwitches[i] = i % 3; // make all the sent values match
     }
 
     // set the nextSwitchIndex so we know which switch to expect in the packet
-    crsf.nextSwitchIndex=3;
+    crsf.nextSwitchIndex = 3;
 
     // use the encoding method to pack it into Radio.TXdataBuffer
     GenerateChannelDataHybridSwitch8(&Radio, &crsf, DeviceAddr);
@@ -187,7 +186,6 @@ void test_decodingHybrid8()
     TEST_ASSERT_EQUAL(SWITCH2b_to_CRSF(crsf.currentSwitches[3] & 0b11), crsf.PackedRCdataOut.ch7); // We forced switch 3 to be sent as the sequential field
 }
 
-
 // ------------------------------------------------------
 // Test the sequential switches encoding/decoding
 
@@ -206,13 +204,13 @@ void test_encodingSEQ()
     crsf.ChannelDataIn[3] = 0xCDEF;
 
     // 8 switches
-    for(int i=0; i<N_SWITCHES; i++) {
+    for(int i = 0; i < N_SWITCHES; i++) {
         crsf.currentSwitches[i] =  i % 3;
         crsf.sentSwitches[i] = i % 3; // make all the sent values match
     }
 
     // set the nextSwitchIndex so we know which switch to expect in the packet
-    crsf.nextSwitchIndex=3;
+    crsf.nextSwitchIndex = 3;
 
     // encode it
     GenerateChannelDataSeqSwitch(&Radio, &crsf, DeviceAddr);
@@ -223,9 +221,9 @@ void test_encodingSEQ()
     TEST_ASSERT_EQUAL(header, Radio.TXdataBuffer[0]);
 
     // bytes 1 through 4 are the high bits of the analog channels
-    for(int i=0; i<4; i++) {
+    for(int i = 0; i < 4; i++) {
         expected = crsf.ChannelDataIn[i] >> 3; // most significant 8 bits
-        TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[i+1]);
+        TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[i + 1]);
     }
 
     // byte 5 contains some bits from the first three channels
@@ -242,7 +240,7 @@ void test_encodingSEQ()
 
     // the sequential switch bits:
     // expect index in 2-4 and value in 0,1
-    TEST_ASSERT_EQUAL(3, (Radio.TXdataBuffer[6] & 0b11100)>>2);
+    TEST_ASSERT_EQUAL(3, (Radio.TXdataBuffer[6] & 0b11100) >> 2);
     TEST_ASSERT_EQUAL(crsf.currentSwitches[3], Radio.TXdataBuffer[6] & 0b11);
 }
 
@@ -263,13 +261,13 @@ void test_decodingSEQ()
     crsf.ChannelDataIn[3] = 0xCDEF;
 
     // 8 switches
-    for(int i=0; i<N_SWITCHES; i++) {
-        crsf.currentSwitches[i] =  (i+1) % 3;
-        crsf.sentSwitches[i] = (i+1) % 3; // make all the sent values match
+    for(int i = 0; i < N_SWITCHES; i++) {
+        crsf.currentSwitches[i] =  (i + 1) % 3;
+        crsf.sentSwitches[i] = (i + 1) % 3; // make all the sent values match
     }
 
     // set the nextSwitchIndex so we know which switch to expect in the packet
-    crsf.nextSwitchIndex=3;
+    crsf.nextSwitchIndex = 3;
 
     // use the encoding method to pack it into Radio.TXdataBuffer
     GenerateChannelDataSeqSwitch(&Radio, &crsf, DeviceAddr);

--- a/src/test/test_switches.cpp
+++ b/src/test/test_switches.cpp
@@ -1,0 +1,137 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include "CRSF.h"
+#include "LoRaRadioLib.h"
+#include "targets.h"
+#include "common.h"
+#include <OTA.h>
+
+CRSF crsf;  // need an instance to provide the fields and code to be tested
+SX127xDriver Radio; // needed for Radio.TXdataBuffer
+
+
+/* Check that the round robin works
+ * First call should return 0 for seq switches or 1 for hybrid
+ * Successive calls should increment the next index until wrap
+ * around from 7 to either 0 or 1 depending on mode.
+ */
+void test_round_robin(void) {
+
+    uint8_t expectedIndex=crsf.nextSwitchIndex;
+
+    for(uint8_t i=0; i<10; i++) {
+        uint8_t nsi = crsf.getNextSwitchIndex();
+        TEST_ASSERT_EQUAL(expectedIndex, nsi);
+        expectedIndex++;
+        if (expectedIndex == 8) {
+#ifdef HYBRID_SWITCHES_8
+            expectedIndex = 1;
+#else
+            expectedIndex = 0;
+#endif
+        }
+    }
+}
+
+/* Check that a changed switch gets priority
+*/
+void test_priority(void) {
+
+    uint8_t nsi;
+
+    crsf.nextSwitchIndex=0; // this would be the next switch if nothing changed
+
+    // set all switches and sent values to be equal
+    for(uint8_t i=0; i<N_SWITCHES; i++) {
+        crsf.sentSwitches[i] = 0;
+        crsf.currentSwitches[i] = 0;
+    }
+
+    // set two switches' current value to be different
+    crsf.currentSwitches[4] = 1;
+    crsf.currentSwitches[6] = 1;
+
+    // we expect to get the lowest changed switch
+    nsi = crsf.getNextSwitchIndex();
+    TEST_ASSERT_EQUAL(4, nsi);
+
+    // The sending code would then change the sent value to match:
+    crsf.sentSwitches[4] = 1;
+
+    // so now we expect to get 6 (the other changed switch we set above)
+    nsi = crsf.getNextSwitchIndex();
+    TEST_ASSERT_EQUAL(6, nsi);
+
+    // The sending code would then change the sent value to match:
+    crsf.sentSwitches[6] = 1;
+
+    // Now all sent values should match the current values, and we expect
+    // to get the last returned value +1
+    nsi = crsf.getNextSwitchIndex();
+    TEST_ASSERT_EQUAL(7, nsi);
+
+}
+
+/* Check the encoding of a packet for OTA tx
+*/
+void test_encoding()
+{
+    uint8_t UID[6] = {MY_UID};
+    uint8_t DeviceAddr = UID[5] & 0b111111;
+    uint8_t expected;
+
+    // Define the input data
+    // 4 channels of analog data
+    crsf.ChannelDataIn[0] = 0x0123;
+    crsf.ChannelDataIn[1] = 0x4567;
+    crsf.ChannelDataIn[2] = 0x89AB;
+    crsf.ChannelDataIn[3] = 0xCDEF;
+
+    // 8 switches
+    for(int i=0; i<N_SWITCHES; i++) {
+        crsf.currentSwitches[i] =  i % 3;
+        crsf.sentSwitches[i] = i % 3; // make all the sent values match
+    }
+
+    // set the nextSwitchIndex so we know which switch to expect in the packet
+    crsf.nextSwitchIndex=3;
+
+    // encode it
+    GenerateChannelDataHybridSwitch8(&Radio, &crsf, DeviceAddr);
+
+    // check it looks right
+    // 1st byte is header & packet type
+    uint8_t header = (DeviceAddr << 2) + RC_DATA_PACKET;
+    TEST_ASSERT_EQUAL(header, Radio.TXdataBuffer[0]);
+
+    // bytes 1 through 5 are 10 bit packed analog channels
+    for(int i=0; i<4; i++) {
+        expected = crsf.ChannelDataIn[i] >> 3; // most significant 8 bits
+        TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[i+1]);
+    }
+
+    // byte 5 is bits 1 and 2 of each analog channel
+    expected = 0;
+    for(int i=0; i<4; i++) {
+        expected = (expected <<2) | ((crsf.ChannelDataIn[i] >> 1) & 0b11);
+    }
+    TEST_ASSERT_EQUAL(expected, Radio.TXdataBuffer[5]);
+
+    // byte 6 is the switch encoding
+    // expect switch 0 in bits 5 and 6, index in 2-4 and value in 0,1
+    // top bit is undefined
+    TEST_ASSERT_EQUAL(crsf.currentSwitches[0], (Radio.TXdataBuffer[6] & 0b01100000)>>5);
+    TEST_ASSERT_EQUAL(3, (Radio.TXdataBuffer[6] & 0b11100)>>2);
+    TEST_ASSERT_EQUAL(crsf.currentSwitches[3], Radio.TXdataBuffer[6] & 0b11);
+}
+
+/* Check the decoding of a packet after rx
+*/
+
+void setup_switches()
+{
+    RUN_TEST(test_round_robin);
+    RUN_TEST(test_priority);
+    RUN_TEST(test_encoding);
+}

--- a/src/test/test_switches.h
+++ b/src/test/test_switches.h
@@ -1,0 +1,3 @@
+// Declare the entry point provided by test_switches
+
+void setup_switches(void);

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -19,6 +19,8 @@
 
 ### ONLY DEFINE ONE OF THE SWITCH ENCODING OPTIONS
 
+# if neither of the below are set the code defaults to 1bit switches
+
 # Sequential switches
 # 5 bits are used in each rc packet to encode 8 3 position switches
 # first 3 bits are the switch ID, followed by 2 bits for the switch value.
@@ -37,7 +39,7 @@
 # channels are reduced to 10bit resolution to free up space in the rc packet
 # for switches.
 
--DHYBRID_SWITCHES_8
+#-DHYBRID_SWITCHES_8
 
 
 ### Set your UID here. Must be 6 bytes!

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -21,6 +21,8 @@
 
 # if neither of the below are set the code defaults to 1bit switches
 
+# NB The TX and RX must be compiled with matching switch protocols!
+
 # Sequential switches
 # 5 bits are used in each rc packet to encode 8 3 position switches
 # first 3 bits are the switch ID, followed by 2 bits for the switch value.

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -17,6 +17,29 @@
 #-DRegulatory_Domain_FCC_915
 
 
+### ONLY DEFINE ONE OF THE SWITCH ENCODING OPTIONS
+
+# Sequential switches
+# 5 bits are used in each rc packet to encode 8 3 position switches
+# first 3 bits are the switch ID, followed by 2 bits for the switch value.
+# Switches that have changed are given priority, otherwise each switch value
+# is sent in round-robin.
+# Channel 4 is reduced to 10bit resolution in order to get the 5th bit needed
+# for sequential switch encoding.
+
+#-DSEQ_SWITCHES
+
+# Hybrid switches
+# The first switch is treated as a low-latency switch to be used for arm/disarm.
+# It is sent with every packet. The remaining 7 switch channels are sent
+# in the same change-prioritized round-robin fashion as described for sequential
+# switches above. All switches are encoded for 3 position support. All analog
+# channels are reduced to 10bit resolution to free up space in the rc packet
+# for switches.
+
+-DHYBRID_SWITCHES_8
+
+
 ### Set your UID here. Must be 6 bytes!
 
 -DMY_UID=0xBA,0xBE,0xCA,0xFE,0xAC,0xDC


### PR DESCRIPTION
Sequential switches sends 1 switch state per RC packet using a 3 bit switch index
and a 2 bit switch value. This supports 8 3-position switches. The transmitter
keeps an array of 'sent' switch values and compares this with the current values
in order to detect switches that have changed value. The lowest index changed
switch is sent to the receiver. If no switches have changed then each switch is
sent in round robin fashion.

For sequential switches the last analog channel is reduced to 10 bit resolution.

Hybrid switch mode sends the lowest index switch with every packet so as to
ensure the lowest possible latency. This switch is intended to be used for
arming. The remaining switches are sent in the same way as described above for
sequential switches. All 8 switches support 3-position output.

For hybrid switches all analog channels are reduced to 10 bit resolution.

New code is off by default. To enable, uncomment one of -DSEQ_SWITCHES or -DHYBRID_SWITCHES_8 in user_defines.txt. The encoding being used must match on the transmitter and receiver.

Signed-off-by: JBKingdon <james.kingdon@gmail.com>