### PR TITLE
Fixed up a typo in the comments for rngN

### DIFF
--- a/src/src/utils.cpp
+++ b/src/src/utils.cpp
@@ -37,7 +37,7 @@ void rngSeed(long newSeed)
     seed = newSeed;
 }
 
-// returns 0<x<max where max <= 256
+// returns 0 <= x < max where max <= 256
 // (actual upper limit is higher, but there is one and I haven't
 //  thought carefully about what it is)
 unsigned int rngN(unsigned int max)

--- a/src/src/utils.h
+++ b/src/src/utils.h
@@ -16,5 +16,5 @@ long rng8Bit(void);
 // 0..31 returned
 long rng5Bit(void);
 
-// returns 0<x<n where n <= 256
+// returns 0 <= x < n where n <= 256
 unsigned int rngN(unsigned int upper);


### PR DESCRIPTION
The original comment claimed the returned value is always > 0
where in reality it is possible for 0 to be returned.

Signed-off-by: JBKingdon <james.kingdon@gmail.com>