### PR TITLE
Fix hwTimer::updateInterval

### DIFF
--- a/src/src/ESP32_hwTimer.cpp
+++ b/src/src/ESP32_hwTimer.cpp
@@ -55,9 +55,9 @@ void ICACHE_RAM_ATTR hwTimer::stop()
 
 void ICACHE_RAM_ATTR hwTimer::updateInterval(uint32_t time)
 {
+    HWtimerInterval = time;
     if (timer)
     {
-        HWtimerInterval = time;
         timerAlarmWrite(timer, HWtimerInterval, true);
     }
 }


### PR DESCRIPTION
hwTimer::updateInterval should set the interval whether the timer
is started or not.