### PR TITLE
Rf mode lock

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -639,7 +639,7 @@ void setup()
     hwTimer.callbackTock = &HWtimerCallbackTock;
     hwTimer.callbackTick = &HWtimerCallbackTick;
 
-    #ifdef LOCKED_ON_50HZ
+    #ifdef LOCK_ON_50HZ
         for (int i = 0; i < RATE_MAX; i++)
         {
             expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig((expresslrs_RFrates_e)i);

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -640,8 +640,15 @@ void setup()
     hwTimer.callbackTick = &HWtimerCallbackTick;
 
     #ifdef LOCKED_ON_50HZ
-        LockRFmode = true;
-        SetRFLinkRate(RATE_50HZ);
+        for (int i = 0; i < RATE_MAX; i++)
+        {
+            expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig((expresslrs_RFrates_e)i);
+            if (ModParams->enum_rate == RATE_50HZ)
+            {
+                SetRFLinkRate(ModParams->index);
+                LockRFmode = true;
+            }
+        }
     #else
         SetRFLinkRate((uint8_t)RATE_DEFAULT);
     #endif

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -105,6 +105,7 @@ uint32_t PacketInterval;
 
 /// Variables for Sync Behaviour ////
 uint32_t RFmodeLastCycled = 0;
+bool LockRFmode = false;
 ///////////////////////////////////////
 
 void ICACHE_RAM_ATTR getRFlinkInfo()
@@ -131,14 +132,17 @@ void ICACHE_RAM_ATTR getRFlinkInfo()
 
 void ICACHE_RAM_ATTR SetRFLinkRate(uint8_t index) // Set speed of RF link (hz)
 {
-    expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
-    expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);
+    if (!LockRFmode)
+    {
+        expresslrs_mod_settings_s *const ModParams = get_elrs_airRateConfig(index);
+        expresslrs_rf_pref_params_s *const RFperf = get_elrs_RFperfParams(index);
 
-    Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen);
-    hwTimer.updateInterval(ModParams->interval);
+        Radio.Config(ModParams->bw, ModParams->sf, ModParams->cr, GetInitialFreq(), ModParams->PreambleLen);
+        hwTimer.updateInterval(ModParams->interval);
 
-    ExpressLRS_currAirRate_Modparams = ModParams;
-    ExpressLRS_currAirRate_RFperfParams = RFperf;
+        ExpressLRS_currAirRate_Modparams = ModParams;
+        ExpressLRS_currAirRate_RFperfParams = RFperf;
+    }
 }
 
 void ICACHE_RAM_ATTR SetTLMRate(expresslrs_tlm_ratio_e TLMrateIn)
@@ -311,6 +315,10 @@ void ICACHE_RAM_ATTR GotConnection()
     {
         return; // Already connected
     }
+
+    #ifdef LOCK_ON_FIRST_CONNECTION
+        LockRFmode = true;
+    #endif
 
     connectionStatePrev = connectionState;
     connectionState = connected; //we got a packet, therefore no lost connection
@@ -631,8 +639,13 @@ void setup()
     hwTimer.callbackTock = &HWtimerCallbackTock;
     hwTimer.callbackTick = &HWtimerCallbackTick;
 
-    SetRFLinkRate((uint8_t)RATE_DEFAULT);
-  
+    #ifdef LOCKED_ON_50HZ
+        LockRFmode = true;
+        SetRFLinkRate(RATE_50HZ);
+    #else
+        SetRFLinkRate((uint8_t)RATE_DEFAULT);
+    #endif
+
     Radio.RXnb();
     crsf.Begin();
     hwTimer.init();

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -16,7 +16,7 @@
 ### STEP1: ### 
 ### Enable one of these regulatory domains by removing a leading '#' ###
 
-#-DRegulatory_Domain_AU_915
+-DRegulatory_Domain_AU_915
 #-DRegulatory_Domain_EU_868
 #-DRegulatory_Domain_AU_433
 #-DRegulatory_Domain_EU_433
@@ -74,3 +74,7 @@
 # Uncomment to use the inverted sbus pad on the r9mm receiver and flight controller.  'set serialrx_inverted = ON' may also need to be set within Betaflight.
 # TLM is not available.  Flashing via the BetaflightPassthrough target will not work!!!
 #-DUSE_R9MM_R9MINI_SBUS
+
+# RF Mode Locking - 
+#-DLOCK_ON_FIRST_CONNECTION
+-DLOCKED_ON_50HZ

--- a/src/user_defines.txt
+++ b/src/user_defines.txt
@@ -16,7 +16,7 @@
 ### STEP1: ### 
 ### Enable one of these regulatory domains by removing a leading '#' ###
 
--DRegulatory_Domain_AU_915
+#-DRegulatory_Domain_AU_915
 #-DRegulatory_Domain_EU_868
 #-DRegulatory_Domain_AU_433
 #-DRegulatory_Domain_EU_433
@@ -75,6 +75,9 @@
 # TLM is not available.  Flashing via the BetaflightPassthrough target will not work!!!
 #-DUSE_R9MM_R9MINI_SBUS
 
-# RF Mode Locking - 
+# RF Mode Locking - Default mode is for the Rx to cycle through the available RF modes and find
+# which mode the Tx transmitting.  LOCK_ON_FIRST_CONNECTION allows the Rx to cycle, but once a connection
+# is made the Rx will no longer cycle through the RF modes.  LOCK_ON_50HZ sets the Rx to only 50Hz
+# mode from the powerup.
 #-DLOCK_ON_FIRST_CONNECTION
--DLOCKED_ON_50HZ
+#-DLOCK_ON_50HZ


### PR DESCRIPTION
RF mode lock for those who only want LR 50hz mode, or to prevent the rx from cycling when RTH is activated.

```
# RF Mode Locking - Default mode is for the Rx to cycle through the available RF modes and find
# which mode the Tx transmitting.  LOCK_ON_FIRST_CONNECTION allows the Rx to cycle, but once a connection
# is made the Rx will no longer cycle through the RF modes.  LOCK_ON_50HZ sets the Rx to only 50Hz
# mode from the powerup.
#-DLOCK_ON_FIRST_CONNECTION
#-DLOCK_ON_50HZ
```