### PR TITLE
always sendLinkStatisticsToFC

### DIFF
--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -719,8 +719,12 @@ void loop()
         GotConnection();
     }
 
-    if ((millis() > (SendLinkStatstoFCintervalLastSent + SEND_LINK_STATS_TO_FC_INTERVAL)) && connectionState != disconnected)
+    if (millis() > (SendLinkStatstoFCintervalLastSent + SEND_LINK_STATS_TO_FC_INTERVAL))
     {
+        if (connectionState == disconnected)
+        {
+            getRFlinkInfo();
+        }
         crsf.sendLinkStatisticsToFC();
         SendLinkStatstoFCintervalLastSent = millis();
     }


### PR DESCRIPTION
Great for seeing what the rx is up to when cycling through rf modes.