### PR TITLE
Fix the ST-Link upload failure if username contains spaces

### DIFF
--- a/src/python/stlink.py
+++ b/src/python/stlink.py
@@ -12,7 +12,7 @@ def get_commands(env, firmware):
 
     flash_start = app_start = 0x08000000
     bootloader = None # env['UPLOAD_FLAGS'][0]
-    upload_flags = env['UPLOAD_FLAGS']
+    upload_flags = env.get('UPLOAD_FLAGS', [])
 
     for line in upload_flags:
         flags = line.split()
@@ -26,11 +26,12 @@ def get_commands(env, firmware):
                 else:
                     offset = int(offset, 10)
                 app_start = flash_start + offset
-
+    env_dir = env['PROJECT_PACKAGES_DIR']
     if "windows" in platform_name:
         TOOL = os.path.join(
-            env['PROJECT_PACKAGES_DIR'],
+            env_dir,
             "tool-stm32duino", "stlink", "ST-LINK_CLI.exe")
+        TOOL = '"%s"' % TOOL
         if bootloader is not None:
             BL_CMD = [TOOL, "-c SWD SWCLK=8 -P",
                 bootloader, hex(flash_start)]
@@ -38,7 +39,7 @@ def get_commands(env, firmware):
             firmware, hex(app_start), "-RST"]
     elif "linux" in platform_name:
         TOOL = os.path.join(
-            env['PROJECT_PACKAGES_DIR'],
+            env_dir,
             "tool-stm32duino", "stlink", "st-flash")
         if bootloader is not None:
             BL_CMD = [TOOL, "write", bootloader, hex(flash_start)]


### PR DESCRIPTION
Tool path must contain \" -marks if computer username contains any white space.
Also fixes issue when `UPLOAD_FLAGS` is not defined.
