### PR TITLE
Update CRSF.cpp to fix erroneous crc failure caused by sending data 

### DIFF
--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -710,6 +710,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
                         if (SerialInPacketPtr > CRSF_MAX_PACKET_LEN - 1) // we reached the maximum allowable packet length, so start again because shit fucked up hey.
                         {
                             SerialInPacketPtr = 0;
+                            SerialInPacketLen = 0;
                             CRSFframeActive = false;
                             return;
                         }
@@ -744,10 +745,14 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
                                     lastUARTpktTime = millis();
                                     delayMicroseconds(50);
                                     CRSF::STM32handleUARTout();
+                                    while (CRSF::Port.available())
+                                    {
+                                        CRSF::Port.read(); // empty any remaining garbled data 
+                                    }
                                     GoodPktsCount++;
                                 }
-
                                 SerialInPacketPtr = 0;
+                                SerialInPacketLen = 0;
                                 CRSFframeActive = false;
                             }
                             else
@@ -755,6 +760,7 @@ void ICACHE_RAM_ATTR CRSF::sendSyncPacketToTX(void *pvParameters) // in values i
                                 Serial.println("UART CRC failure");
                                 CRSFframeActive = false;
                                 SerialInPacketPtr = 0;
+                                SerialInPacketLen = 0;
                                 while (CRSF::Port.available())
                                 {
                                     CRSF::Port.read(); // empty any remaining garbled data 


### PR DESCRIPTION
After a uart response packet is sent it seems to corrupt the output buffer which results in a false crc error. This fix makes sure that the buffer is flushed after we write to it.