### PR TITLE
make led pin configurable

### DIFF
--- a/src/src/LED.h
+++ b/src/src/LED.h
@@ -1,10 +1,9 @@
 /// LED SUPPORT ///////
-#ifdef PLATFORM_ESP32
+#if defined(PLATFORM_ESP32) && defined(GPIO_PIN_LED)
 #include <NeoPixelBus.h>
 const uint16_t PixelCount = 1; // this example assumes 1 pixel
-const uint8_t PixelPin = 27;   // make sure to set this to the correct pin, ignored for Esp8266
 #define colorSaturation 50
-NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, PixelPin);
+NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> strip(PixelCount, GPIO_PIN_LED);
 
 RgbColor red(colorSaturation, 0, 0);
 RgbColor green(0, colorSaturation, 0);
@@ -21,7 +20,7 @@ HslColor hslBlack(black);
 
 void updateLEDs(uint8_t isRXconnected, uint8_t tlm)
 {
-#ifdef PLATFORM_ESP32
+#if defined(PLATFORM_ESP32) && defined(GPIO_PIN_LED)
     if (ExpressLRS_currAirRate_Modparams->enum_rate == RATE_200HZ)
     {
         strip.ClearTo(RgbColor(0, 0, LED_MAX_BRIGHTNESS));

--- a/src/src/targets.h
+++ b/src/src/targets.h
@@ -27,6 +27,7 @@
 #define GPIO_PIN_OLED_SCK 15
 #define GPIO_PIN_RCSIGNAL_RX 13
 #define GPIO_PIN_RCSIGNAL_TX 13
+#define GPIO_PIN_LED 2
 #endif
 
 #ifdef TARGET_TTGO_LORA_V1_AS_RX
@@ -64,6 +65,7 @@
 #define GPIO_PIN_TX_ENABLE 12
 #define GPIO_PIN_RCSIGNAL_RX 2
 #define GPIO_PIN_RCSIGNAL_TX 2 // so we don't have to solder the extra resistor, we switch rx/tx using gpio mux
+#define GPIO_PIN_LED 27
 #endif
 
 #ifdef TARGET_EXPRESSLRS_PCB_TX_V3_LEGACY

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -581,7 +581,9 @@ void setup()
 
 #ifdef PLATFORM_ESP32
   //WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detector needed for debug, shouldn't need to be actually used in practise.
+#ifdef GPIO_PIN_LED
   strip.Begin();
+#endif
   // Get base mac address
   esp_read_mac(baseMac, ESP_MAC_WIFI_STA);
   // Print base mac address


### PR DESCRIPTION
fixes overlap between other pins (for example TTGO v1 MOSI) and the rgb led on ESP32 platforms.
commit assumes that TARGET_EXPRESSLRS_PCB_TX_V3 has the led pin actually on 27.  