### PR TITLE
fix compiler warnings

### DIFF
--- a/src/lib/BUTTON/button.cpp
+++ b/src/lib/BUTTON/button.cpp
@@ -1,6 +1,6 @@
 #include "button.h"
 
-void inline button::nullCallback(void){};
+void inline button::nullCallback(void) {}
 void (*button::buttonShortPress)() = &nullCallback; // callbacks
 void (*button::buttonLongPress)() = &nullCallback;  // callbacks
 

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -35,7 +35,7 @@ uint8_t CRSF::CSFR_RXpin_Module = GPIO_PIN_RCSIGNAL_RX; // Same pin for RX/TX
 volatile bool CRSF::ignoreSerialData = false;
 volatile bool CRSF::CRSFframeActive = false; //since we get a copy of the serial data use this flag to know when to ignore it
 
-void inline CRSF::nullCallback(void){};
+void inline CRSF::nullCallback(void) {}
 
 void (*CRSF::RCdataCallback1)() = &nullCallback; // null placeholder callback
 void (*CRSF::RCdataCallback2)() = &nullCallback; // null placeholder callback
@@ -201,7 +201,7 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 
 void ICACHE_RAM_ATTR CRSF::sendLUAresponse(uint8_t val[])
 {
-    uint8_t dataLength = sizeof(val);
+    uint8_t dataLength = 4;
     uint8_t LUArespLength = dataLength + 2;
 
     uint8_t outBuffer[LUArespLength + 4] = {0};
@@ -287,7 +287,7 @@ void ICACHE_RAM_ATTR CRSF::JustSentRFpacket()
 {
     CRSF::OpenTXsyncOffset = micros() - CRSF::RCdataLastRecv;
 
-    if (CRSF::OpenTXsyncOffset > CRSF::RequestedRCpacketInterval) // detect overrun case when the packet arrives too late and caculate negative offsets.
+    if (CRSF::OpenTXsyncOffset > (int32_t)CRSF::RequestedRCpacketInterval) // detect overrun case when the packet arrives too late and caculate negative offsets.
     {
         CRSF::OpenTXsyncOffset = -(CRSF::OpenTXsyncOffset % CRSF::RequestedRCpacketInterval);
 #ifdef FEATURE_OPENTX_SYNC_AUTOTUNE

--- a/src/lib/CRSF/CRSF.cpp
+++ b/src/lib/CRSF/CRSF.cpp
@@ -201,7 +201,7 @@ void ICACHE_RAM_ATTR CRSF::sendLinkStatisticsToTX()
 
 void ICACHE_RAM_ATTR CRSF::sendLUAresponse(uint8_t val[])
 {
-    uint8_t dataLength = 4;
+    uint8_t dataLength = sizeof(val);
     uint8_t LUArespLength = dataLength + 2;
 
     uint8_t outBuffer[LUArespLength + 4] = {0};

--- a/src/lib/CRSF/CRSF.h
+++ b/src/lib/CRSF/CRSF.h
@@ -281,13 +281,13 @@ typedef struct crsfPayloadLinkstatistics_s crsfLinkStatistics_t;
 /////inline and utility functions//////
 
 //static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, float in_min, float in_max, float out_min, float out_max) { return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min; };
-static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) { return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min; };
+static uint16_t ICACHE_RAM_ATTR fmap(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) { return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min; }
 
-static inline uint16_t ICACHE_RAM_ATTR CRSF_to_US(uint16_t Val) { return round(fmap(Val, 172.0, 1811.0, 988.0, 2012.0)); };
-static inline uint16_t ICACHE_RAM_ATTR UINT10_to_CRSF(uint16_t Val) { return round(fmap(Val, 0.0, 1024.0, 172.0, 1811.0)); };
+static inline uint16_t ICACHE_RAM_ATTR CRSF_to_US(uint16_t Val) { return round(fmap(Val, 172.0, 1811.0, 988.0, 2012.0)); }
+static inline uint16_t ICACHE_RAM_ATTR UINT10_to_CRSF(uint16_t Val) { return round(fmap(Val, 0.0, 1024.0, 172.0, 1811.0)); }
 
 // 2b switches use 0, 1 and 2 as values to represent low, middle and high
-static inline uint16_t ICACHE_RAM_ATTR SWITCH2b_to_CRSF(uint16_t Val) { return round(map(Val, 0, 2, 188, 1795)); };
+static inline uint16_t ICACHE_RAM_ATTR SWITCH2b_to_CRSF(uint16_t Val) { return round(map(Val, 0, 2, 188, 1795)); }
 
 static inline uint8_t ICACHE_RAM_ATTR CRSF_to_BIT(uint16_t Val)
 {
@@ -295,16 +295,17 @@ static inline uint8_t ICACHE_RAM_ATTR CRSF_to_BIT(uint16_t Val)
         return 1;
     else
         return 0;
-};
+}
+
 static inline uint16_t ICACHE_RAM_ATTR BIT_to_CRSF(uint8_t Val)
 {
     if (Val)
         return 1795;
     else
         return 188;
-};
+}
 
-static inline uint16_t ICACHE_RAM_ATTR CRSF_to_UINT10(uint16_t Val) { return round(fmap(Val, 172.0, 1811.0, 0.0, 1023.0)); };
+static inline uint16_t ICACHE_RAM_ATTR CRSF_to_UINT10(uint16_t Val) { return round(fmap(Val, 172.0, 1811.0, 0.0, 1023.0)); }
 //static inline uint16_t ICACHE_RAM_ATTR UINT_to_CRSF(uint16_t Val);
 
 static inline uint8_t ICACHE_RAM_ATTR CalcCRC(volatile uint8_t *data, int length)

--- a/src/lib/HWTIMER/ESP32_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP32_hwTimer.cpp
@@ -5,7 +5,7 @@
 static hw_timer_t *timer = NULL;
 static portMUX_TYPE isrMutex = portMUX_INITIALIZER_UNLOCKED;
 
-void hwTimer::nullCallback(void){};
+void hwTimer::nullCallback(void) {}
 void (*hwTimer::callbackTock)() = &nullCallback;
 
 volatile uint32_t hwTimer::HWtimerInterval = TimerIntervalUSDefault;

--- a/src/lib/HWTIMER/ESP8266_hwTimer.cpp
+++ b/src/lib/HWTIMER/ESP8266_hwTimer.cpp
@@ -1,7 +1,7 @@
 #ifdef PLATFORM_ESP8266
 #include "ESP8266_hwTimer.h"
 
-void inline hwTimer::nullCallback(void){};
+void inline hwTimer::nullCallback(void) {}
 
 void (*hwTimer::callbackTick)() = &nullCallback;
 void (*hwTimer::callbackTock)() = &nullCallback;

--- a/src/lib/HWTIMER/STM32_hwTimer.cpp
+++ b/src/lib/HWTIMER/STM32_hwTimer.cpp
@@ -1,7 +1,7 @@
 #ifdef PLATFORM_STM32
 #include "STM32_hwTimer.h"
 
-void inline hwTimer::nullCallback(void){};
+void inline hwTimer::nullCallback(void) {}
 
 void (*hwTimer::callbackTick)() = &nullCallback; // function is called whenever there is new RC data.
 void (*hwTimer::callbackTock)() = &nullCallback; // function is called whenever there is new RC data.

--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -2,7 +2,7 @@
 
 SX127xHal hal;
 
-void inline SX127xDriver::nullCallback(void){};
+void inline SX127xDriver::nullCallback(void) {}
 SX127xDriver *SX127xDriver::instance = NULL;
 
 void (*SX127xDriver::RXdoneCallback)() = &nullCallback;
@@ -127,7 +127,7 @@ void SX127xDriver::SetBandwidthCodingRate(SX127x_Bandwidth bw, SX127x_CodingRate
 
 bool SyncWordOk(uint8_t syncWord)
 {
-  for (int i = 0; i < sizeof(SX127x_AllowedSyncwords); i++)
+  for (unsigned int i = 0; i < sizeof(SX127x_AllowedSyncwords); i++)
   {
     if (syncWord == SX127x_AllowedSyncwords[i])
     {

--- a/src/lib/SX127xDriver/SX127xHal.cpp
+++ b/src/lib/SX127xDriver/SX127xHal.cpp
@@ -4,7 +4,7 @@ SX127xHal *SX127xHal::instance = NULL;
 
 volatile SX127x_InterruptAssignment SX127xHal::InterruptAssignment = SX127x_INTERRUPT_NONE;
 
-void inline SX127xHal::nullCallback(void) { return; };
+void inline SX127xHal::nullCallback(void) { return; }
 void (*SX127xHal::TXdoneCallback)() = &nullCallback;
 void (*SX127xHal::RXdoneCallback)() = &nullCallback;
 

--- a/src/lib/SX1280Driver/SX1280.cpp
+++ b/src/lib/SX1280Driver/SX1280.cpp
@@ -66,6 +66,8 @@ bool SX1280Driver::Begin()
     this->SetFrequency(this->currFreq);                                     //Step 3: Set Freq
     this->SetFIFOaddr(0x00, 0x00);                                          //Step 4: Config FIFO addr
     this->SetDioIrqParams(SX1280_IRQ_RADIO_ALL, SX1280_IRQ_TX_DONE | SX1280_IRQ_RX_DONE, SX1280_IRQ_RADIO_NONE, SX1280_IRQ_RADIO_NONE); //set IRQ to both RXdone/TXdone on DIO1
+
+    return true;
 }
 
 void ICACHE_RAM_ATTR SX1280Driver::Config(SX1280_RadioLoRaBandwidths_t bw, SX1280_RadioLoRaSpreadingFactors_t sf, SX1280_RadioLoRaCodingRates_t cr, uint32_t freq, uint8_t PreambleLength)

--- a/src/lib/SX1280Driver/SX1280_hal.cpp
+++ b/src/lib/SX1280Driver/SX1280_hal.cpp
@@ -22,7 +22,7 @@ Modified and adapted by Alessandro Carcione for ELRS project
 
 SX1280Hal *SX1280Hal::instance = NULL;
 
-void ICACHE_RAM_ATTR SX1280Hal::nullCallback(void){};
+void ICACHE_RAM_ATTR SX1280Hal::nullCallback(void) {}
 
 void (*SX1280Hal::TXdoneCallback)() = &nullCallback;
 void (*SX1280Hal::RXdoneCallback)() = &nullCallback;

--- a/src/src/rx_main.cpp
+++ b/src/src/rx_main.cpp
@@ -107,7 +107,7 @@ bool LockRFmode = false;
 
 void ICACHE_RAM_ATTR getRFlinkInfo()
 {
-    int8_t LastRSSI = Radio.LastPacketRSSI;
+    //int8_t LastRSSI = Radio.LastPacketRSSI;
     int32_t rssiDBM = LPF_UplinkRSSI.update(Radio.LastPacketRSSI);
 
     crsf.PackedRCdataOut.ch15 = UINT10_to_CRSF(map(rssiDBM, -100, -50, 0, 1023));

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -518,7 +518,12 @@ void HandleUpdateParameter()
   }
 
   UpdateParamReq = false;
-  uint8_t luaCurrParams[] = {ExpressLRS_currAirRate_Modparams->enum_rate + 3, ExpressLRS_currAirRate_Modparams->TLMinterval + 1, POWERMGNT.currPower() + 2, Regulatory_Domain_Index};
+  uint8_t luaCurrParams[] = {
+    (uint8_t)(ExpressLRS_currAirRate_Modparams->enum_rate + 3), 
+    (uint8_t)(ExpressLRS_currAirRate_Modparams->TLMinterval + 1), 
+    (uint8_t)(POWERMGNT.currPower() + 2),
+    Regulatory_Domain_Index
+  };
   crsf.sendLUAresponse(luaCurrParams);
 }
 
@@ -771,7 +776,7 @@ void OnTxPowerPacket(mspPacket_t *packet)
 void OnTLMRatePacket(mspPacket_t *packet)
 {
   // Parse the TLM rate
-  uint8_t tlmRate = packet->readByte();
+  // uint8_t tlmRate = packet->readByte();
   CHECK_PACKET_PARSING();
 
   // TODO: Implement dynamic TLM rates

--- a/src/src/utils.cpp
+++ b/src/src/utils.cpp
@@ -7,7 +7,7 @@ unsigned long seed = 0;
 // behaviour rngN will need updating
 long rng(void)
 {
-    long m = 2147483648;
+    unsigned long m = 2147483648;
     long a = 214013;
     long c = 2531011;
     seed = (a * seed + c) % m;


### PR DESCRIPTION
I compliled the project with "-Wall -pedantic" and noticed some warnings that I fixed in this PR.

Most are of cosmetic nature but in CRSF::sendLUAresponse the response length is incorrect. I noticed that this is also changed in the new lua branch #161 so we could exclude it from this PR.