### PR TITLE
added r9slim+ different pins

### DIFF
--- a/src/src/targets.h
+++ b/src/src/targets.h
@@ -117,6 +117,11 @@ https://github.com/jaxxzer
     #define GPIO_PIN_LED_RED        PB2 // Red
     #define GPIO_PIN_LED_GREEN      PB3 // Green 
     #define GPIO_PIN_BUTTON         PB0  // pullup e.g. LOW when pressed
+#elif TARGET_R9SLIM_RX
+    #define GPIO_PIN_LED            PA11 // Red
+    #define GPIO_PIN_LED_RED        PA11 // Red
+    #define GPIO_PIN_LED_GREEN      PA12 // Green 
+    #define GPIO_PIN_BUTTON         PC13  // pullup e.g. LOW when pressed
 #else
     #define GPIO_PIN_LED            PC1 // Red
     #define GPIO_PIN_LED_RED        PC1 // Red


### PR DESCRIPTION
Most of the pins match as you guys proposed. I am still not sure about led pins, they beep with USB_DP and USB_DM pins of STM. I wasn't able to find them on other pins. Also on the board itself there are two chips named Sky 3330, next to antennas (will provide picture in Discord). I think those are the rf switchers, but why two of them?!
Here is a link of the closest thing I was able to find with that name:
[https://store.skyworksinc.com/products/detail/sky13330397lf-skyworks/419942/](https://store.skyworksinc.com/products/detail/sky13330397lf-skyworks/419942/) 