### PR TITLE
Fix R9 RX monitor_speed

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -146,6 +146,7 @@ upload_flags =
 lib_deps =
     https://github.com/PaoloP74/extEEPROM.git
 	Wire
+monitor_speed = 420000
 
 [env:Frsky_RX_R9MM_R9MINI_via_BetaflightPassthrough]
 platform = ${env:Frsky_RX_R9MM_R9MINI_via_STLINK.platform}
@@ -161,6 +162,7 @@ upload_command =
 	python python/runpython.py $PYTHONEXE python/BFinitPassthrough.py 420000
 	python python/runpython.py $PYTHONEXE python/UARTupload.py $SOURCE
 lib_deps = ${env:Frsky_RX_R9MM_R9MINI_via_STLINK.lib_deps}
+monitor_speed = 420000
 
 [env:Frsky_RX_R9SLIMPLUS_via_BetaflightPassthrough]
 platform = ststm32@8.0.0
@@ -185,6 +187,7 @@ upload_command =
 lib_deps =
 	https://github.com/PaoloP74/extEEPROM.git
 	Wire
+monitor_speed = 420000
 
 [env:Frsky_RX_R9MX_via_STLINK]
 platform = ststm32@8.0.0
@@ -211,6 +214,7 @@ upload_flags =
 lib_deps =
 	https://github.com/PaoloP74/extEEPROM.git
 	Wire
+monitor_speed = 420000
 
 [env:Frsky_RX_R9MX_via_BetaflightPassthrough]
 platform = ${env:Frsky_RX_R9MX_via_STLINK.platform}
@@ -225,6 +229,7 @@ upload_command =
 	python python/runpython.py $PYTHONEXE python/BFinitPassthrough.py 420000
 	python python/runpython.py $PYTHONEXE python/UARTupload.py $SOURCE
 lib_deps = ${env:Frsky_RX_R9MX_via_STLINK.lib_deps}
+monitor_speed = 420000
 
 [env:DIY_900_TX_TTGO_V1_SX127x_via_UART]
 platform = espressif32@1.12.0


### PR DESCRIPTION
Monitor speed is set to 9600 baud by default. Fix RX envs to use correct 420k baud .