### PR TITLE
Fix timing check on Link rate changes to try and prevent hangs.

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -423,7 +423,7 @@ void HandleUpdateParameter()
     Serial.println("Change Link rate");
     if ((ExpressLRS_currAirRate_Modparams->index != enumRatetoIndex((expresslrs_RFrates_e)crsf.ParameterUpdateData[1])))
     {
-      if ((micros() + PacketLastSentMicros) > ExpressLRS_currAirRate_Modparams->interval) // special case, if we haven't waited long enough to ensure that the last packet hasn't been sent we exit.
+      if ((micros() - PacketLastSentMicros) > ExpressLRS_currAirRate_Modparams->interval) // special case, if we haven't waited long enough to ensure that the last packet hasn't been sent we exit.
       {
         SetRFLinkRate(enumRatetoIndex((expresslrs_RFrates_e)crsf.ParameterUpdateData[1]));
         Serial.println(ExpressLRS_currAirRate_Modparams->enum_rate);


### PR DESCRIPTION
With my ELRS2.bas script for ErskyTx I was noticing ELRS would hang occasionally when rapidly changing the packet rate setting. This would manifest as the serial debugging no longer generating any output and loss of link.
It did not seem to happen when changing the other parameters so I looked at the air-rate change code and noticed this code error.
Since fixing it I have not been able to reproduce the hang.

By the way, while investigating this bug I did a global search for micros() and noticed this other bug that could cause (potentially rare) failures:
In SX1280Driver\SX1280_hal.cpp:
if (micros() > startTime + wtimeoutUS)

This should be:
if ((micros() - startTime) > wtimeoutUS)
to avoid possible failures every ~1.2 hours when micros() wraps around. 
The subtraction makes the wrap around safe due to the nature of twos complement arithmetic.
I have not fixed this because I do not have a 2.4G module.