### PR TITLE
Improve reliability of air-rate changes

### DIFF
--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -420,15 +420,23 @@ void HandleUpdateParameter()
     break;
 
   case 1:
-    Serial.println("Change Link rate");
     if ((ExpressLRS_currAirRate_Modparams->index != enumRatetoIndex((expresslrs_RFrates_e)crsf.ParameterUpdateData[1])))
     {
       if ((micros() + PacketLastSentMicros) > ExpressLRS_currAirRate_Modparams->interval) // special case, if we haven't waited long enough to ensure that the last packet hasn't been sent we exit.
       {
+        Serial.println("Change Link rate");
         SetRFLinkRate(enumRatetoIndex((expresslrs_RFrates_e)crsf.ParameterUpdateData[1]));
         Serial.println(ExpressLRS_currAirRate_Modparams->enum_rate);
-        hwTimer.resume();
+
+        //Commenting out this reduces the "UART CRC failure" debug messages
+        //hwTimer.resume(); 
       }
+      else
+      {
+         //Serial.println("Change Link rate postponed");
+         return; //try again later
+      }
+      
     }
     break;
 

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -422,7 +422,7 @@ void HandleUpdateParameter()
   case 1:
     if ((ExpressLRS_currAirRate_Modparams->index != enumRatetoIndex((expresslrs_RFrates_e)crsf.ParameterUpdateData[1])))
     {
-      if ((micros() + PacketLastSentMicros) > ExpressLRS_currAirRate_Modparams->interval) // special case, if we haven't waited long enough to ensure that the last packet hasn't been sent we exit.
+      if ((micros() - PacketLastSentMicros) > ExpressLRS_currAirRate_Modparams->interval) // special case, if we haven't waited long enough to ensure that the last packet hasn't been sent we exit.
       {
         Serial.println("Change Link rate");
         SetRFLinkRate(enumRatetoIndex((expresslrs_RFrates_e)crsf.ParameterUpdateData[1]));


### PR DESCRIPTION
After my fix to prevent hangs resulting from too frequent air-rate changes, I found that every second air-rate change command had no effect. While this was not nearly as serious as the hangs, it made the UI in the script a bit annoying.
I found that returning from HandleUpdateParameter() immediately so that UpdateParamReq is left true so that the change will be applied at a future call from loop() fixed this issue.
I also noticed that letting the eeprom write finished code resume the timer reduced the number of "UART CRC failure" debug messages. Of course, removing the resume directly after calling SetRFLinkRate() would cause problems if writing to the eeprom was disabled, so this change might not be wanted.