### PR TITLE
bugfix - additional null checks on uart upload / com-port detection

### DIFF
--- a/src/python/serials_find.py
+++ b/src/python/serials_find.py
@@ -19,8 +19,8 @@ def serial_ports():
             print("  ** Searching flight controllers **")
             __ports = list(comports())
             for port in __ports:
-                if port.manufacturer in ['FTDI', 'Betaflight', ] or \
-                        "STM32" in port.product or port.vid == 0x0483:
+                if (port.manufacturer and port.manufacturer in ['FTDI', 'Betaflight', ]) or \
+                        (port.product and "STM32" in port.product) or (port.vid and port.vid == 0x0483):
                     print("      > FC found from '%s'" % port.device)
                     ports.append(port.device)
     except ImportError:


### PR DESCRIPTION
PySerial doesn't define the object attributes if those attributes are empty. Trying to access those attributes if they're undefined would throw a `TypeError: argument of type 'NoneType' is not iterable` error.

Explicit null checking instead of wrapping in a try/catch statement so it doesn't short-circuit the following checks, if a previous one would fail.

Here's some example "possibilities", first with an actual FC, second with.. I don't even know what that COM port does.
```js
{'description': 'Serielles USB-Gerät (COM5)',
 'device': 'COM5',
 'hwid': 'USB VID:PID=0483:5740 SER=0X8000000 LOCATION=1-10',
 'interface': None,
 'location': '1-10',
 'manufacturer': 'Microsoft',
 'name': 'COM5',
 'pid': 22336,
 'product': None,
 'serial_number': '0X8000000',
 'vid': 1155}

{'description': 'Kommunikationsanschluss (COM1)',
 'device': 'COM1',
 'hwid': 'ACPI\\PNP0501\\0',
 'interface': None,
 'location': None,
 'manufacturer': '(Standardanschlusstypen)',
 'name': 'COM1',
 'pid': None,
 'product': None,
 'serial_number': None,
 'vid': None}