### PR TITLE
reverse serial list to have best chance of hitting correct serial port

### DIFF
--- a/src/python/serials_find.py
+++ b/src/python/serials_find.py
@@ -52,7 +52,7 @@ def serial_ports():
             if "permission denied" in str(error).lower():
                 raise Exception("You don't have persmission to use serial port!")
             pass
-    return result
+    return result.reverse()
 
 def get_serial_port(debug=True):
     result = serial_ports()


### PR DESCRIPTION
Thought this simple change of reversing the serial port list order would have a higher chance of hitting the correct serial port for flashing.