### PR TITLE
Added r9m lite target via stock bl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         pio run --environment Frsky_TX_R9M_via_stock_BL 
         pio run --environment Frsky_TX_R9M_via_WIFI 
         pio run --environment Frsky_TX_R9M_LITE_via_STLINK 
+        pio run --environment Frsky_TX_R9M_LITE_via_stock_BL
         pio run --environment Frsky_TX_R9M_LITE_PRO_via_STLINK 
         pio run --environment Frsky_RX_R9MM_R9MINI_via_STLINK 
         pio run --environment Frsky_RX_R9MM_R9MINI_via_BetaflightPassthrough 

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -83,6 +83,21 @@ upload_flags =
 src_filter = ${env:Frsky_TX_R9M_via_STLINK.src_filter}
 lib_deps = ${env:Frsky_TX_R9M_via_STLINK.lib_deps}
 
+[env:Frsky_TX_R9M_LITE_via_stock_BL]
+platform = ststm32@8.0.0
+board = bluepill_f103c8
+build_unflags = -Os
+build_flags =
+	-D TARGET_R9M_LITE_TX
+	-D PLATFORM_STM32
+	-D HSE_VALUE=12000000U
+	-O2
+	-DVECT_TAB_OFFSET=0x4000U
+board_build.ldscript = variants/R9M_stock_ldscript.ld
+board_build.flash_offset = 0x4000
+src_filter = ${env:Frsky_TX_R9M_LITE_via_STLINK.src_filter}
+lib_deps = ${env:Frsky_TX_R9M_LITE_via_STLINK.lib_deps}
+
 [env:Frsky_TX_R9M_LITE_PRO_via_STLINK]
 platform = ststm32@9.0.0
 board = robotdyn_blackpill_f303cc


### PR DESCRIPTION
Added the r9m lite as target to be used with the full size r9m bootloader; discussion can be found here: https://discordapp.com/channels/596350022191415318/738450139693449258/784787875676815421

Flash regular r9m elrs bootloader to r9m lite via radio, then flash new target to r9m lite via radio. STLink is no longer needed.

Edit: Of course, wiki would need to be edited a bit to explain the flashing procedure for the r9m lite. :)