### PR TITLE
Fix R9M flash offset

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -19,6 +19,7 @@ monitor_speed = 420000
 monitor_dtr = 0
 monitor_rts = 0
 
+## TODO: R9M STLINK/stock and R9M Lite targets can be merged
 [env:Frsky_TX_R9M_via_STLINK]
 platform = ststm32@8.0.0
 board = bluepill_f103c8
@@ -28,13 +29,13 @@ build_flags =
 	-D PLATFORM_STM32
 	-D HSE_VALUE=12000000U
 	-O2
-	-DVECT_TAB_OFFSET=0x2000U
+	-DVECT_TAB_OFFSET=0x4000U
 board_build.ldscript = variants/R9M_ldscript.ld
-board_build.flash_offset = 0x2000
+board_build.flash_offset = 0x4000
 src_filter = ${common_env_data.src_filter} -<ESP32*.*> -<ESP8266*.*> -<WS281B*.*> -<rx_*.cpp>
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
-	VECT_OFFSET=0x2000
+	VECT_OFFSET=0x4000
 lib_deps =
 	https://github.com/PaoloP74/extEEPROM.git
 
@@ -74,12 +75,12 @@ build_flags =
 	-D PLATFORM_STM32
 	-D HSE_VALUE=12000000U
 	-O2
-	-DVECT_TAB_OFFSET=0x2000U
+	-DVECT_TAB_OFFSET=0x4000U
 board_build.ldscript = variants/R9M_ldscript.ld
-board_build.flash_offset = 0x2000
+board_build.flash_offset = 0x4000
 upload_flags =
 	BOOTLOADER=bootloader/r9m_bootloader.bin
-	VECT_OFFSET=0x2000
+	VECT_OFFSET=0x4000
 src_filter = ${env:Frsky_TX_R9M_via_STLINK.src_filter}
 lib_deps = ${env:Frsky_TX_R9M_via_STLINK.lib_deps}
 
@@ -237,8 +238,8 @@ upload_flags =
     VECT_OFFSET=0x8000
 lib_deps = ${env:Jumper_RX_R900MINI_via_BetaflightPassthrough.lib_deps}
 
-[env:Jumper_RX_R900MINI_via_BetaflightPassthrough]  
-platform = ststm32@8.0.0 
+[env:Jumper_RX_R900MINI_via_BetaflightPassthrough]
+platform = ststm32@8.0.0
 board = bluepill_f103c8
 build_unflags = -Os
 build_flags =
@@ -446,7 +447,7 @@ upload_command =
 	python python/runpython.py $PYTHONEXE python/BFinitPassthrough.py $UPLOAD_SPEED
 	python $PROJECT_PACKAGES_DIR/framework-arduinoespressif32/tools/esptool.py --no-stub -b $UPLOAD_SPEED -c esp8266 --before no_reset --after soft_reset write_flash 0x0000 $SOURCE
 
-[env:DIY_2400_RX_STM32_CCG_Nano_v0_5] 
+[env:DIY_2400_RX_STM32_CCG_Nano_v0_5]
 platform = ststm32@9.0.0
 board = l432kb
 # max size = 131072 - 0x4000 = 114688
@@ -475,7 +476,7 @@ lib_deps =
 	Wire
 lib_ignore = SX127xDriver
 
-[env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough] 
+[env:DIY_2400_RX_STM32_CCG_Nano_v0_5_via_BetaflightPassthrough]
 platform = ${env:DIY_2400_RX_STM32_CCG_Nano_v0_5.platform}
 board = ${env:DIY_2400_RX_STM32_CCG_Nano_v0_5.board}
 board_upload.maximum_size = ${env:DIY_2400_RX_STM32_CCG_Nano_v0_5.board_upload.maximum_size}

--- a/src/python/build_env_setup.py
+++ b/src/python/build_env_setup.py
@@ -15,7 +15,6 @@ if stm and "$UPLOADER $UPLOADERFLAGS" in env.get('UPLOADCMD', '$UPLOADER $UPLOAD
             env.Replace(UPLOADCMD=upload_via_esp8266_backpack.on_upload)
         else:
             env.AddPostAction("buildprog", [opentx.gen_elrs, opentx.gen_frsky])
-            #env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [opentx.gen_elrs, opentx.gen_frsky]) ## this doesn't work for some reason, returns .elf instead of .bin 
             if "STOCK" not in target_name:
                 env.Replace(UPLOADCMD=stlink.on_upload)
     elif "_STLINK" in target_name:

--- a/src/python/opentx.py
+++ b/src/python/opentx.py
@@ -16,8 +16,8 @@ def gen_multi_bin(source, target, env):
 
 
 def gen_elrs(source, target, env):
-    if not "_stock" in env['PIOENV']:
-        return
+    #if not "_stock" in env['PIOENV']:
+    #    return
     source_bin = source[0]
     sys.stdout.write("Source bin: %s \n" % source_bin)
     bin_path = os.path.dirname(source_bin.rstr())


### PR DESCRIPTION
Same flash offset is used for all R9M targets from bootloader v0.5.3 onwards.