### PR TITLE
targets: fixes R9M Lite target define

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -56,9 +56,15 @@ lib_deps = ${env:Frsky_TX_R9M_via_STLINK.lib_deps}
 
 [env:Frsky_TX_R9M_LITE_via_STLINK]
 extends = env:Frsky_TX_R9M_via_STLINK
+build_flags =
+	-D TARGET_R9M_LITE_TX
+	-D PLATFORM_STM32
+	-D HSE_VALUE=12000000U
+	-O2
+	-DVECT_TAB_OFFSET=0x4000U
 
 [env:Frsky_TX_R9M_LITE_via_stock_BL]
-extends = env:Frsky_TX_R9M_via_STLINK
+extends = env:Frsky_TX_R9M_LITE_via_STLINK
 
 [env:Frsky_TX_R9M_LITE_PRO_via_STLINK]
 platform = ststm32@9.0.0


### PR DESCRIPTION
I made mistake and didn't notice different R9M Lite specific target define... Sorry!