### PR TITLE
fixed properly writing next correct sync word based on the lookup

### DIFF
--- a/src/lib/SX127xDriver/SX127x.cpp
+++ b/src/lib/SX127xDriver/SX127x.cpp
@@ -153,7 +153,7 @@ void SX127xDriver::SetSyncWord(uint8_t syncWord)
     Serial.println(syncWord);
   }
 
-  hal.writeRegister(SX127X_REG_SYNC_WORD, syncWord);
+  hal.writeRegister(SX127X_REG_SYNC_WORD, _syncWord);
   currSyncWord = _syncWord;
 }
 


### PR DESCRIPTION
This probably didn't come up, cause we always use default LORA sync word of 0x12, but the logic was writing the original syncWord even if incorrect so I fixed it. Maybe we should remove the lookup and just write whatever is passed on?